### PR TITLE
kafka-load-test

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/ingest-load-tester.iml
+++ b/.idea/ingest-load-tester.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.7 (ingest-load-tester)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Jinja2" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,26 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ourVersions">
+        <value>
+          <list size="2">
+            <item index="0" class="java.lang.String" itemvalue="3.7" />
+            <item index="1" class="java.lang.String" itemvalue="3.8" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="confluent-kafka" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7 (ingest-load-tester)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/ingest-load-tester.iml" filepath="$PROJECT_DIR$/.idea/ingest-load-tester.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/default_config/kafka_consumers.test.yml
+++ b/default_config/kafka_consumers.test.yml
@@ -2,16 +2,16 @@ users:
   Outcomes:
     wait_time: between(1.1, 1.2)
     num_projects: 10
-    weight: 1
+    weight: 0
     task_set:
       tasks:
-        kafka_consumers_lt.accepted_outcome:
+        accepted_outcome:
           weight: 0
-        kafka_consumers_lt.rate_limited_outcome:
+        rate_limited_outcome:
           weight: 0
-        kafka_consumers_lt.random_outcome:
+        random_outcome:
           weight: 0
-        kafka_consumers_lt.kafka_configurable_outcome_factory:
+        kafka_configurable_outcome_factory:
           weight: 1
           accepted: 0
           filtered: 1
@@ -24,6 +24,35 @@ users:
     weight: 1
     task_set:
       tasks:
-        - kafka_consumers_lt.kafka.small_event
-        - kafka_consumers_lt.kafka.medium_event
-        - kafka_consumers_lt.kafka.large_event
+        random_kafka_event_task_factory:
+          weight: 1
+          send_outcome: true
+          with_level: true
+
+          # How many issues to create.
+          num_event_groups: 10
+
+          max_message_length: 500
+
+          # Amount of users to generate, if null (~), users will just be
+          # entirely random IPv4 addresses.
+          max_users: ~
+
+          # Breadcrumb options
+          min_breadcrumbs: 0
+          max_breadcrumbs: 50
+          breadcrumb_categories: ~
+          breadcrumb_levels: ~
+          breadcrumb_types: ~
+          breadcrumb_messages: ~
+
+          # Amount of random releases to generate.
+          num_releases: 10
+
+          # Add a native stacktrace such that symbolicator is part of the
+          # equation. The debug files necessary for processing the stacktrace
+          # can be found in the native-images/ folder and can be uploaded with:
+          #
+          #   sentry-cli upload-dif . --org sentry --project internal
+          with_native_stacktrace: false
+

--- a/default_config/simple.test.yml
+++ b/default_config/simple.test.yml
@@ -10,9 +10,9 @@ users:
     weight: 0
     task_set:
       tasks:
-        - simple_locustfile.small_event_task
-        - simple_locustfile.medium_event_task
-        - simple_locustfile.large_event_task
+        - small_event_task
+        - medium_event_task
+        - large_event_task
 
   # A task that generates random events based on config parameters
   RandomEvents:
@@ -21,14 +21,14 @@ users:
     weight: 1
     task_set:
       tasks:
-        simple_locustfile.random_envelope_event_task_factory:
+        random_envelope_event_task_factory:
           weight: 0
           # This task generally accepts the same arguments as `random_event_task_factory`.
           with_level: true
           num_event_groups: 1
           num_releases: 10
 
-        simple_locustfile.random_event_task_factory:
+        random_event_task_factory:
           weight: 1
           with_level: true
 

--- a/infrastructure/configurable_locust.py
+++ b/infrastructure/configurable_locust.py
@@ -90,7 +90,9 @@ def _get_wait_time(locust_info):
     return eval(wait_expr, globals(), env_locals)
 
 
-def create_locust_class(name, config_file_name, module_name,  host=None, base_classes=None):
+def create_locust_class(
+    name, config_file_name, module_name, host=None, base_classes=None
+):
     if base_classes is None:
         base_classes = (HttpLocust,)
 

--- a/infrastructure/generators/event.py
+++ b/infrastructure/generators/event.py
@@ -22,7 +22,6 @@ def base_event_generator(
     with_event_id=True,
     with_level=True,
     num_event_groups=1,
-    max_message_length=10000,
     max_users=None,
     min_breadcrumbs=None,
     max_breadcrumbs=None,
@@ -32,6 +31,7 @@ def base_event_generator(
     breadcrumb_messages=None,
     with_native_stacktrace=False,
     num_releases=10,
+    **kwargs  # absorbs parameters used by other parts of the task set configuration
 ):
     event_generator = schema_generator(
         event_id=(lambda: uuid.uuid4().hex) if with_event_id else None,

--- a/infrastructure/generators/event.py
+++ b/infrastructure/generators/event.py
@@ -22,7 +22,6 @@ def base_event_generator(
     with_event_id=True,
     with_level=True,
     num_event_groups=1,
-    max_message_length=10000,
     max_users=None,
     min_breadcrumbs=None,
     max_breadcrumbs=None,
@@ -32,6 +31,7 @@ def base_event_generator(
     breadcrumb_messages=None,
     with_native_stacktrace=False,
     num_releases=10,
+    **kwargs,  # absorbs parameters used by other parts of the task set configuration
 ):
     event_generator = schema_generator(
         event_id=(lambda: uuid.uuid4().hex) if with_event_id else None,

--- a/infrastructure/util.py
+++ b/infrastructure/util.py
@@ -89,19 +89,24 @@ def get_at_path(obj, path, default=None):
     return sub_obj
 
 
-def load_object(name: str):
+def load_object(name: str, locust_module_name):
     """
     Loads an object (class, function, etc) from its name.
 
     Note: Relative names will be resolved relative to this module (and it is not a recommended practice).
     For reliable results specify the full class name i.e. `package.module.object_name`
     """
-    class_offset = name.rfind(".")
-    if class_offset == -1:
-        object = locals().get(name)
+    last_dot_offset = name.rfind(".")
+
+    if last_dot_offset == -1:
+        # the task is specified relative to the locust module
+        # append the locust file module name to the name
+        module_name = locust_module_name
     else:
-        module = import_module(name[:class_offset])
-        object = getattr(module, name[class_offset + 1 :])
+        module_name = name[:last_dot_offset]
+
+    module = import_module(module_name)
+    object = getattr(module, name[last_dot_offset + 1 :])
 
     if object is None:
         raise ValueError("Could not find object", name)

--- a/kafka_consumers_locustfile.py
+++ b/kafka_consumers_locustfile.py
@@ -12,24 +12,21 @@ from tasks.kafka_tasks import (
     kafka_outcome_task,
     kafka_random_outcome_task,
     kafka_configurable_outcome_task_factory,
-    canned_kafka_event_task,
+    random_kafka_event_task_factory,
 )
 
 accepted_outcome = kafka_outcome_task(Outcome.ACCEPTED)
 rate_limited_outcome = kafka_outcome_task(Outcome.RATE_LIMITED)
 random_outcome = kafka_random_outcome_task
 kafka_configurable_outcome_factory = kafka_configurable_outcome_task_factory
-
-kafka_small_event = canned_kafka_event_task("small_event", send_outcome=True)
-kafka_medium_event = canned_kafka_event_task("medium_event", send_outcome=True)
-kafka_large_event = canned_kafka_event_task("large_event", send_outcome=True)
+random_kafka_event_task_factory = random_kafka_event_task_factory
 
 _config_path = full_path_from_module_relative_path(
     __file__, "config/kafka_consumers.test.yml"
 )
 Outcomes = create_locust_class(
-    "Outcomes", _config_path, __name__,  base_classes=(Locust, KafkaProducerMixin)
+    "Outcomes", _config_path, __name__, base_classes=(Locust, KafkaProducerMixin)
 )
 Events = create_locust_class(
-    "Events", _config_path, __name__,  base_classes=(Locust, KafkaProducerMixin)
+    "Events", _config_path, __name__, base_classes=(Locust, KafkaProducerMixin)
 )

--- a/kafka_consumers_locustfile.py
+++ b/kafka_consumers_locustfile.py
@@ -12,17 +12,14 @@ from tasks.kafka_tasks import (
     kafka_outcome_task,
     kafka_random_outcome_task,
     kafka_configurable_outcome_task_factory,
-    canned_kafka_event_task,
+    random_kafka_event_task_factory,
 )
 
 accepted_outcome = kafka_outcome_task(Outcome.ACCEPTED)
 rate_limited_outcome = kafka_outcome_task(Outcome.RATE_LIMITED)
 random_outcome = kafka_random_outcome_task
 kafka_configurable_outcome_factory = kafka_configurable_outcome_task_factory
-
-kafka_small_event = canned_kafka_event_task("small_event", send_outcome=True)
-kafka_medium_event = canned_kafka_event_task("medium_event", send_outcome=True)
-kafka_large_event = canned_kafka_event_task("large_event", send_outcome=True)
+random_kafka_event_task_factory = random_kafka_event_task_factory
 
 _config_path = full_path_from_module_relative_path(
     __file__, "config/kafka_consumers.test.yml"

--- a/kafka_consumers_locustfile.py
+++ b/kafka_consumers_locustfile.py
@@ -25,11 +25,11 @@ kafka_medium_event = canned_kafka_event_task("medium_event", send_outcome=True)
 kafka_large_event = canned_kafka_event_task("large_event", send_outcome=True)
 
 _config_path = full_path_from_module_relative_path(
-    __file__, "config/kafka_consumers_load_test.yml"
+    __file__, "config/kafka_consumers.test.yml"
 )
 Outcomes = create_locust_class(
-    "Outcomes", _config_path, base_classes=(Locust, KafkaProducerMixin)
+    "Outcomes", _config_path, __name__,  base_classes=(Locust, KafkaProducerMixin)
 )
 Events = create_locust_class(
-    "Events", _config_path, base_classes=(Locust, KafkaProducerMixin)
+    "Events", _config_path, __name__,  base_classes=(Locust, KafkaProducerMixin)
 )

--- a/simple_locustfile.py
+++ b/simple_locustfile.py
@@ -14,5 +14,5 @@ random_event_task_factory = event_tasks.random_event_task_factory
 random_envelope_event_task_factory = event_tasks.random_envelope_event_task_factory
 
 _config_path = full_path_from_module_relative_path(__file__, "config/simple.test.yml")
-SimpleLoadTest = create_locust_class("SimpleLoadTest", _config_path)
-RandomEvents = create_locust_class("RandomEvents", _config_path)
+SimpleLoadTest = create_locust_class("SimpleLoadTest", _config_path, __name__)
+RandomEvents = create_locust_class("RandomEvents", _config_path, __name__)

--- a/tasks/event_tasks.py
+++ b/tasks/event_tasks.py
@@ -44,17 +44,11 @@ def canned_envelope_event_task(event_name: str):
     return inner
 
 
-def _get_task_config_args(task_params):
-    return {k: v for k, v in task_params.items() if k != "weight"}
-
-
 def random_event_task_factory(task_params=None):
-    if task_params is not None:
-        kwargs = _get_task_config_args(task_params)
-    else:
-        kwargs = {}
+    if task_params is None:
+        task_params = {}
 
-    event_generator = base_event_generator(**kwargs)
+    event_generator = base_event_generator(**task_params)
 
     def inner(task_set: TaskSet):
         event = event_generator()
@@ -66,12 +60,9 @@ def random_event_task_factory(task_params=None):
 
 
 def random_envelope_event_task_factory(task_params=None):
-    if task_params is not None:
-        kwargs = _get_task_config_args(task_params)
-    else:
-        kwargs = {}
-
-    event_generator = base_event_generator(**kwargs)
+    if task_params is None:
+        task_params = {}
+    event_generator = base_event_generator(**task_params)
 
     def inner(task_set: TaskSet):
         event = event_generator()


### PR DESCRIPTION
Allow locust file relative task names (no more module.task)
Use event_generator for kafka events