### PR TITLE
feat: Use uwsgi for fake-sentry server

### DIFF
--- a/fake_sentry/fake_sentry.py
+++ b/fake_sentry/fake_sentry.py
@@ -168,6 +168,8 @@ def run_blocking_fake_sentry(config):
 
 
 def configure_app(config):
+    app = Flask(__name__)
+
     log_level = config.get("log_level", logging.INFO)
     logging.getLogger("werkzeug").setLevel(log_level)
     app.logger.setLevel(log_level)
@@ -237,6 +239,8 @@ def configure_app(config):
         app.logger.error("Fake sentry error generated error:\n{}".format(e))
         abort(400)
 
+    return app
+
 
 def _get_config():
     """
@@ -255,9 +259,8 @@ def _get_config():
         raise ValueError("Invalid configuration")
 
 
-app = Flask(__name__)
 config = _get_config()
-configure_app(config)
+app = configure_app(config)
 
 if __name__ == "__main__":
     run_blocking_fake_sentry(config)

--- a/fake_sentry/fake_sentry.py
+++ b/fake_sentry/fake_sentry.py
@@ -156,11 +156,12 @@ def run_blocking_fake_sentry(config):
     port = config.get("port")
 
     if config.get("use_uwsgi", True):
-        # Exec uwsgi with some default parameters
+        # Exec uwsgi with some default parameters.
+        # Parameters can be tweaked by setting certain environment variables.
+        # For example, to change the number of uwsgi workers, set UWSGI_PROCESSES=<N> (1 by default)
         mywsgi.run(
             "fake_sentry.fake_sentry:app",
             "{}:{}".format(host or "127.0.0.1", port or 8000),
-            processes=os.environ.get("UWSGI_PROCESSES") or 4,
         )
     else:
         app.run(host=host, port=port)
@@ -191,7 +192,6 @@ def configure_app(config):
     def check_challenge():
         relay_id = flask_request.json["relay_id"]
         assert relay_id == flask_request.headers["x-sentry-relay-id"]
-        assert relay_id in authenticated_relays
         return jsonify({"relay_id": relay_id})
 
     @app.route("/api/0/relays/projectconfigs/", methods=["POST"])

--- a/fake_sentry/fake_sentry.py
+++ b/fake_sentry/fake_sentry.py
@@ -1,19 +1,19 @@
-from queue import Queue
-
-from flask import Flask, request as flask_request, jsonify, abort
-import logging
-import threading
 import datetime
-import time
+import logging
 import os
+import time
+import threading
 import uuid
-
+from queue import Queue
 from yaml import load
 
+import mywsgi
+from flask import Flask, request as flask_request, jsonify, abort
+
 try:
-    from yaml import CLoader as Loader, CDumper as Dumper, CFullLoader as FullLoader
+    from yaml import CFullLoader as FullLoader
 except ImportError:
-    from yaml import Loader, Dumper, FullLoader
+    from yaml import FullLoader
 
 from infrastructure.util import full_path_from_module_relative_path
 
@@ -141,7 +141,7 @@ def run_fake_sentry_async(config):
     :param config: the cli configuration
     :return: the thread in which the fake
     """
-    t = threading.Thread(target=_fake_sentry_thread, args=(config,))
+    t = threading.Thread(target=run_blocking_fake_sentry, args=(config,))
     t.daemon = True
     t.start()
     return t
@@ -152,17 +152,25 @@ def run_blocking_fake_sentry(config):
     Runs a fake sentry server on the current thread (this is a blocking call)
     :param config: the cli configuration
     """
-    _fake_sentry_thread(config)
+    host = config.get("host")
+    port = config.get("port")
+
+    if config.get("use_uwsgi", True):
+        # Exec uwsgi with some default parameters
+        mywsgi.run(
+            "fake_sentry.fake_sentry:app",
+            "{}:{}".format(host or "127.0.0.1", port or 8000),
+            processes=os.environ.get("UWSGI_PROCESSES") or 4,
+        )
+    else:
+        app.run(host=host, port=port)
 
 
-def _fake_sentry_thread(config):
-    app = Flask(__name__)
-
+def configure_app(config):
     log_level = config.get("log_level", logging.INFO)
     logging.getLogger("werkzeug").setLevel(log_level)
     app.logger.setLevel(log_level)
 
-    # sentry = None
     host = config.get("host")
     port = config.get("port")
     dns_public_key = config.get("key")
@@ -229,8 +237,6 @@ def _fake_sentry_thread(config):
         app.logger.error("Fake sentry error generated error:\n{}".format(e))
         abort(400)
 
-    app.run(host=host, port=port)
-
 
 def _get_config():
     """
@@ -249,6 +255,9 @@ def _get_config():
         raise ValueError("Invalid configuration")
 
 
+app = Flask(__name__)
+config = _get_config()
+configure_app(config)
+
 if __name__ == "__main__":
-    config = _get_config()
     run_blocking_fake_sentry(config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ confluent-kafka==1.4.1
 msgpack>=0.6.1,<0.7.0
 sentry-relay==0.5.9
 black==19.10b0
+mywsgi==1.0.3
+uWSGI==2.0.18

--- a/simple_locustfile.py
+++ b/simple_locustfile.py
@@ -1,5 +1,14 @@
+import resource
+
+# Raise the max number of open files
+current_limits = resource.getrlimit(resource.RLIMIT_NOFILE)
+new_limit = min(current_limits[1], 1000000)
+resource.setrlimit(resource.RLIMIT_NOFILE, (new_limit, new_limit))
+
+###
 from infrastructure import full_path_from_module_relative_path, create_locust_class
 from tasks import event_tasks
+
 
 # do NOT just import the functions in the module (you will get a warning that the function is not used,
 # you will remove it and then will get a runtime error)


### PR DESCRIPTION
To make fake-sentry more performant, run it with uwsgi, so that we can control the number of workers.
E.g., running with 16 processes will look like
```
UWSGI_PROCESSES=16 make fake-sentry
```