### PR TITLE
fix: Remove max_message_len

### DIFF
--- a/default_config/kafka_consumers.test.yml
+++ b/default_config/kafka_consumers.test.yml
@@ -32,8 +32,6 @@ users:
           # How many issues to create.
           num_event_groups: 10
 
-          max_message_length: 500
-
           # Amount of users to generate, if null (~), users will just be
           # entirely random IPv4 addresses.
           max_users: ~

--- a/default_config/simple.test.yml
+++ b/default_config/simple.test.yml
@@ -39,8 +39,6 @@ users:
           # How many issues to create.
           num_event_groups: 10
 
-          max_message_length: 500
-
           # Amount of users to generate, if null (~), users will just be
           # entirely random IPv4 addresses.
           max_users: ~


### PR DESCRIPTION
New installations are breaking because of this field.
Guess it was renamed/removed?