### PR TITLE
feat: Support version 2 of projectconfigs endpoint

### DIFF
--- a/fake_sentry/fake_sentry.py
+++ b/fake_sentry/fake_sentry.py
@@ -213,10 +213,12 @@ def configure_app(config):
 
     @app.route("/api/0/relays/projectconfigs/", methods=["POST"])
     def get_project_config():
+        assert flask_request.args.get("version") == "2"
         rv = {}
-        for project_id in flask_request.json["projects"]:
-            app.logger.debug("getting project config for: {}".format(project_id))
-            rv[project_id] = sentry.full_project_config()
+        for public_key in flask_request.json["publicKeys"]:
+            app.logger.debug("getting project config for: {}".format(public_key))
+            rv[public_key] = sentry.full_project_config()
+            rv[public_key]["publicKeys"][0]["publicKey"] = public_key
         return jsonify(configs=rv)
 
     @app.route("/api/0/relays/publickeys/", methods=["POST"])

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -72,7 +72,10 @@ def generate_project_info(num_projects) -> ProjectInfo:
 
     if use_fake_projects:
         project_id = project_idx + 1
-        project_key = config["fake_projects"]["key"]
+        project_key_base = config["fake_projects"]["key"]
+        project_key = hex(int(project_key_base, 16) + project_id)[2:].rjust(
+            len(project_key_base), "0"
+        )[: len(project_key_base)]
     else:
         project_cfg = config["projects"][project_idx]
         project_id = project_cfg["id"]


### PR DESCRIPTION
In the first version of projectconfigs endpoint projects were identified
by a numeric ID. Since the second version, they are instead identified by
the public key. This means we have to look at projects a bit differently.

The bulk of the change is actually telling load generator to use different
public keys for different projects. The key in the config is assumed to be
a hex number (a long one, sure) and the project ID is added (mathematically)
to it, then it goes back to hex.