### PR TITLE
ref(build): Switch to artifact registry in sentry-st-testing

### DIFF
--- a/push-image.sh
+++ b/push-image.sh
@@ -6,11 +6,9 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-IMAGE="us.gcr.io/sentryio/ingest-load-tester"
-# uncomment next line to push to sentry testing repo
-# IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/ingest-load-tester"
+IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/ingest-load-tester"
 TAG=$(git rev-parse HEAD)
 
-docker build -t $IMAGE:$TAG .
+docker build -t "${IMAGE}:${TAG}" .
 
-docker push $IMAGE:$TAG
+docker push "${IMAGE}:${TAG}"


### PR DESCRIPTION
Let's have all the testing-related images in one place for now, to simplify permissions and configuration.