### PR TITLE
build: Install venv without virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ setup-venv: .venv/bin/python
 
 .venv/bin/python:
 	@rm -rf .venv
-	@which virtualenv || sudo easy_install virtualenv
-	virtualenv -p $$PYTHON_VERSION .venv
+	python3 -m venv --copies .venv
+	.venv/bin/pip install -U pip wheel
 	.venv/bin/pip install -U -r requirements.txt
 
 format: setup-venv


### PR DESCRIPTION
With python 3 and `venv`, it is possible to bootstrap a virtual environment
without installing `virtualenv` or even requiring `pip` on the machine. This
reduces requirements on the development machine.

Note that this uses `--copies` when installing the venv to ensure that Make
doesn't recreate the virtual environment on every run.
