### PR TITLE
meta: Update codeowners to owners-qe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @getsentry/owners-ingest
+*   @getsentry/owners-qe


### PR DESCRIPTION
Makes the new @getsentry/owners-qe team as code owners for this repository.
