### PR TITLE
ref(metrics): Remove computed measurements from ingestion [INGEST-1057]

### DIFF
--- a/default_config/projects/default.json
+++ b/default_config/projects/default.json
@@ -60,13 +60,10 @@
         "sentry.transactions.measurements.app_start_cold",
         "sentry.transactions.measurements.stall_count",
         "sentry.transactions.measurements.stall_longest_time",
-        "sentry.transactions.measurements.stall_percentage",
         "sentry.transactions.measurements.stall_total_time",
         "sentry.transactions.measurements.frames_slow",
-        "sentry.transactions.measurements.frames_slow_rate",
         "sentry.transactions.measurements.frames_frozen",
-        "sentry.transactions.measurements.frames_total",
-        "sentry.transactions.measurements.frames_frozen_rate"
+        "sentry.transactions.measurements.frames_total"
       ],
       "extractCustomTags": [
         "myCustomTag"


### PR DESCRIPTION
There are a few measurement metrics that are [computed in
discover](https://github.com/getsentry/sentry/blob/9d55755b45a128406c7aff87209d1e0056d27742/src/sentry/search/events/fields.py#L380-L418)
from other metrics and thus, there's no need to extract these in
ingestion. The dependent metrics are still extracted and not removed
from ingestion.

These are also removed in Sentry, see https://github.com/getsentry/sentry/pull/33725.