### PR TITLE
feat(fake-sentry): "Support" project configs API v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM python:3.6-bullseye
+FROM python:3.8-slim
 
-RUN apt-get update && apt-get install -y git wget curl
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y git wget curl build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY docker-entrypoint.sh /
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # ingest-load-tester
 
-Legacy load testing tool for Relay.
+> ### IMPORTANT NOTE: This is our legacy load tester, new tests should preferably be developed in [go-load-tester](https://github.com/getsentry/go-load-tester).
 
-### IMPORTANT NOTE
-This is our legacy load tester, new tests should preferably be devloped in  [go-load-tester](https://github.com/getsentry/go-load-tester). 
-
-## Load test contains tools for load testing relay.
 
 The project contains two tools: a load tester based on Locust (see https://locust.io/) and a
 fake Sentry server that contains just enough functionality to get relay working with an upstream.
 
-## Fake Sentry Server
+## Component: Fake Sentry Server
 
 The FakeSentryServer runs a Flask server that responds to the security challenge messages from Relay and
 is able to provide project configurations for any project (it responds with a canned project configuration)
@@ -26,7 +22,7 @@ For example, to achieve higher throughput, one can raise the number of workers a
 
     UWSGI_LISTEN=10000 UWSGI_PROCESSES=16 make fake-sentry
 
-## Load tester
+## Component: Load tester
 
 ### Installation
 
@@ -103,20 +99,20 @@ Please consult the locust documentation for details: https://docs.locust.io/en/1
 
 Locust uses a Python file as a load testing entrypoint.
 
-`ingest-load-tester` uses Locust internally and adds the facility to configure tests by using yaml files. Under the hood `ingest-load-tester` 
+`ingest-load-tester` uses Locust internally and adds the facility to configure tests by using yaml files. Under the hood `ingest-load-tester`
 creates locust tests classes that are derived from `ConfigurableUser` class which in turn is derived from the locust `UserClass`.
 
 The `ConfigurableUser` class adds functionality that allows the tests to be configured from a yaml file.
 
 Two locust files are provided ([simple_locustfile.py](https://github.com/getsentry/ingest-load-tester/blob/master/simple_locustfile.py) and [kafka_consumers_locustfile.py](https://github.com/getsentry/ingest-load-tester/blob/master/kafka_consumers_locustfile.py)) and , and others can be easily added. The files have the following structure:
 * import all the task factories that you intend ot use in your user classes in the file
-* define the user classes 
+* define the user classes
 * in the user class configuration use one or more of the imported task factories to define tests.
 
-The tests are structured on two levels, at the top level there are the ConfigurableUser derived classes 
+The tests are structured on two levels, at the top level there are the ConfigurableUser derived classes
 and each class contains one or more task factories. A task factory is used to generate requests.
 
-At both levels there is a configurable weight parameter. The weights are relative to the other weights at the 
+At both levels there is a configurable weight parameter. The weights are relative to the other weights at the
 same level. An example would illustrate what happens.
 
 Presume that in your Locust file you have defined 2 test classes: `Purchase` and `Browse`. In
@@ -170,7 +166,7 @@ Uses the same event generator as the envelope event generators but sends it to k
 
 ### session generator
 
-Envelope based generator for sessions. 
+Envelope based generator for sessions.
 
 The following parameters can be configured:
 * number of releases
@@ -199,7 +195,7 @@ It supports configurations for:
 * loggers
 * transaction
 * contexts
-    
+
 ### transaction generator
 
 Envelope based generator for Transactions.

--- a/fake_sentry/fake_sentry.py
+++ b/fake_sentry/fake_sentry.py
@@ -1,22 +1,21 @@
-import atexit
 import datetime
 import gzip
-from infrastructure.config import locust_config
 import json
 import logging
 import os
 import resource
-import time
 import threading
+import time
 import uuid
-from queue import Queue
-from yaml import load
 from logging.config import dictConfig
 from pprint import pformat
-from sentry_sdk.envelope import Envelope
+from queue import Queue
 
 import mywsgi
-from flask import Flask, request as flask_request, jsonify, abort
+from flask import Flask, abort, jsonify
+from flask import request as flask_request
+from sentry_sdk.envelope import Envelope
+from yaml import load
 
 try:
     from yaml import CFullLoader as FullLoader
@@ -192,7 +191,7 @@ def configure_app(config):
 
     @app.route("/api/0/relays/projectconfigs/", methods=["POST"])
     def get_project_config():
-        assert flask_request.args.get("version") == "2"
+        assert flask_request.args.get("version") in {"2", "3"}
         rv = {}
         _log.debug(f"f project configs request:\n{pformat(flask_request.json)}")
         for public_key in flask_request.json["publicKeys"]:
@@ -313,7 +312,7 @@ def load_proj_config(project_key):
         try:
             with open(file_name, "rt") as f:
                 return json.load(f)
-        except:
+        except Exception:
             pass
 
     default_config_name = os.path.join(dir_path, "default.json")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+ignore = E501,E266
+max-line-length = 120
+exclude = .tox,.git,*/migrations/*,docs/*,node_modules/*,venv,.venv,.pytest_cache
+
+[isort]
+profile = black


### PR DESCRIPTION
A few changes:
* Main: fake-sentry now doesn't throw an error when v3 project configs are requested.
* black-ify `fake_sentry.py`
* Bump Python version in Dockerfile to 3.8. Without it some components refused to be installed.
* Some minor updates in README.





_(yes yes, we want to deprecate this repo, I know 😬)_