### PR TITLE
Fixes and multiprocess workers

### DIFF
--- a/ansible/roles/worker/templates/locust-worker.service.j2
+++ b/ansible/roles/worker/templates/locust-worker.service.j2
@@ -10,7 +10,7 @@ Environment="PATH=/opt/ingest-load-tester/.venv/bin"
 ExecStart=/opt/ingest-load-tester/.venv/bin/locust \
     -f s4s2_locustfile.py \
     --worker \
-    --processes 2 \
+    --processes {{ worker_processes | default(1) }} \
     --master-host={{ hostvars[groups['master'][0]]['host_ip'] }}
 Restart=on-failure
 RestartSec=5s

--- a/ansible/roles/worker/templates/locust-worker.service.j2
+++ b/ansible/roles/worker/templates/locust-worker.service.j2
@@ -10,6 +10,7 @@ Environment="PATH=/opt/ingest-load-tester/.venv/bin"
 ExecStart=/opt/ingest-load-tester/.venv/bin/locust \
     -f s4s2_locustfile.py \
     --worker \
+    --processes 2 \
     --master-host={{ hostvars[groups['master'][0]]['host_ip'] }}
 Restart=on-failure
 RestartSec=5s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 description = "Locust based load generation tool for sentry ingestion."
 readme = "README.md"
 dependencies =[
-    "locust==2.8.6",
+    "locust==2.20.0",
     "flask==2.2.0",
     "werkzeug==2.2.2",
     "pyyaml",
     #confluent-kafka==1.6.0
-    "msgpack>=0.6.1,<0.7.0",
+    "msgpack>=1.0.0",
     "sentry-relay==0.9.0",
     "black==22.3.0",
     "mywsgi==1.0.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-locust==2.8.6
+locust==2.20.0
 flask==2.2.0
 werkzeug==2.2.2
 pyyaml
 #confluent-kafka==1.6.0
-msgpack>=0.6.1,<0.7.0
+msgpack>=1.0.0
 sentry-relay==0.9.0
 black==22.3.0
 mywsgi==1.0.3

--- a/s4s2_locustfile.py
+++ b/s4s2_locustfile.py
@@ -26,7 +26,7 @@ replay_envelope_task_factory = event_tasks.replay_envelope_task_factory
 # Load config and add config to factories.
 _config_path = full_path_from_module_relative_path(__file__, "config/s4s2.test.yml")
 
-# TransactionEvents = create_user_class("TransactionEvents", _config_path, __name__)
+TransactionEvents = create_user_class("TransactionEvents", _config_path, __name__)
 # SimpleLoadTest = create_user_class("SimpleLoadTest", _config_path, __name__)
 RandomEvents = create_user_class("RandomEvents", _config_path, __name__)
 LogEvents = create_user_class("LogEvents", _config_path, __name__)

--- a/tasks/event_tasks.py
+++ b/tasks/event_tasks.py
@@ -495,6 +495,10 @@ def span_envelope_task_factory(task_params=None):
         envelope = Envelope(headers=headers)
         envelope.add_item(item)
 
+        return send_envelope(user.client, project_info.id, project_info.key, envelope)
+
+    return inner
+
 
 def replay_envelope_task_factory(task_params=None):
     """

--- a/uv.lock
+++ b/uv.lock
@@ -328,8 +328,8 @@ requires-dist = [
     { name = "black", specifier = "==22.3.0" },
     { name = "flask", specifier = "==2.2.0" },
     { name = "influxdb-client", specifier = "==1.24.0" },
-    { name = "locust", specifier = "==2.8.6" },
-    { name = "msgpack", specifier = ">=0.6.1,<0.7.0" },
+    { name = "locust", specifier = "==2.20.0" },
+    { name = "msgpack", specifier = ">=1.0.0" },
     { name = "mywsgi", specifier = "==1.0.3" },
     { name = "pyyaml" },
     { name = "sentry-relay", specifier = "==0.9.0" },
@@ -360,7 +360,7 @@ wheels = [
 
 [[package]]
 name = "locust"
-version = "2.8.6"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "configargparse", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -369,18 +369,16 @@ dependencies = [
     { name = "flask-cors", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "gevent", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "geventhttpclient", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "msgpack", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "psutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyzmq", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "roundrobin", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "werkzeug", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/34/5d7d9ba02a60ef1187a57b6ef69f39c7b269977803c7dfdc052607b6fd86/locust-2.8.6.tar.gz", hash = "sha256:011b16b5cf8b8cafe51c74cf86234afc6660ec7bdefbc6a89d6648548e1cc1be", size = 1278129, upload-time = "2022-04-07T18:35:58.911Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/0f/007b949af056943715071cdf62e309cbd9d6164367b557a80db462750534/locust-2.20.0.tar.gz", hash = "sha256:b6f78af64bc5066babe54836f796469906cd606b01f34ee788986d0b1fbac99a", size = 2271744, upload-time = "2023-12-13T12:40:30.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/e0/2f7ffdc644a5e420bc6595f9bfb4fb408c41a6307425c26f755b6fc08854/locust-2.8.6-py3-none-any.whl", hash = "sha256:30dd8be2b9518ec06f4f18e061b2b625851faccadc70ffbc146b38f9b377b3d3", size = 806679, upload-time = "2022-04-07T18:35:57.417Z" },
+    { url = "https://files.pythonhosted.org/packages/38/79/2c9cad7ade49f870ccec5aa529049fade7205a4af4ff7a819cbf52af17cf/locust-2.20.0-py3-none-any.whl", hash = "sha256:8092dde31c4cfb43b9b40470ffc7c5f95b3a491dfcb813bb50567edec28451dc", size = 1374801, upload-time = "2023-12-13T12:40:26.418Z" },
 ]
 
 [[package]]
@@ -437,9 +435,29 @@ wheels = [
 
 [[package]]
 name = "msgpack"
-version = "0.6.2"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/0a/de673c1c987f5779b65ef69052331ec0b0ebd22958bda77a8284be831964/msgpack-0.6.2.tar.gz", hash = "sha256:ea3c2f859346fcd55fc46e96885301d9c2f7a36d453f5d8f2967840efa1e1830", size = 119062, upload-time = "2019-09-20T07:42:46.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+]
 
 [[package]]
 name = "mypy-extensions"
@@ -668,15 +686,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Fix mistakes related to a bad merge in the last set of changes
- Upgrade locust
- Add `--processes` to workers so that larger load generator machines can be utilized.
- Add TransactionEvents back to the user list for s4s2