### PR TITLE
feat: add Sentry read API load test types for P0 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Presuming that you are in the load-tests directory you can run:
     make TEST=kafka_consumers load-test
     make TEST=read_api load-test
 
-These tests will run with the configuration files `config/simple.test.yml`, `config/kafka_consumers.test.yml`, and `config/sentry_read_api.test.yml` respectively.
+These tests will run with the configuration files `config/simple.test.yml`, `config/kafka_consumers.test.yml`, and `config/read_api.test.yml` respectively.
 
 Which will ensure that the virtual environment is installed and set up and will call:
 `.venv/bin/locust -f simple_locustfile.py`
@@ -256,7 +256,7 @@ synthetic RRWeb recording data (mouse movements, clicks, scrolls, etc.).
 Load tests for Sentry's highest-traffic read API endpoints. Unlike the envelope/kafka tasks above which
 test the ingest (write) path, these tasks issue authenticated GET requests against Sentry's REST API.
 
-Requires a `SENTRY_AUTH_TOKEN` environment variable (or `auth_token` in the task config) with org-level
+Requires an `AUTH_TOKEN` environment variable (or `auth_token` in the task config) with org-level
 read access.
 
 | Task | Endpoint | Description | Key Config |

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Presuming that you are in the load-tests directory you can run:
 
     make TEST=simple load-test
     make TEST=kafka_consumers load-test
+    make TEST=read_api load-test
 
-These tests will run with the configuration files `config/simple.test.yml` and `config/kafka_consumers.test.yml` respectively.
+These tests will run with the configuration files `config/simple.test.yml`, `config/kafka_consumers.test.yml`, and `config/sentry_read_api.test.yml` respectively.
 
 Which will ensure that the virtual environment is installed and set up and will call:
 `.venv/bin/locust -f simple_locustfile.py`
@@ -249,3 +250,20 @@ The following parameters can be configured:
 
 Each replay_event is accompanied by the configured number of replay_recording segments, which contain
 synthetic RRWeb recording data (mouse movements, clicks, scrolls, etc.).
+
+## Read API
+
+Load tests for Sentry's highest-traffic read API endpoints. Unlike the envelope/kafka tasks above which
+test the ingest (write) path, these tasks issue authenticated GET requests against Sentry's REST API.
+
+Requires a `SENTRY_AUTH_TOKEN` environment variable (or `auth_token` in the task config) with org-level
+read access.
+
+| Task | Endpoint | Description | Key Config |
+|---|---|---|---|
+| Organization Group Index | `GET /api/0/organizations/{org}/issues/` | Issues list — highest-volume read endpoint | stats_periods, limits, sort_options, queries |
+| Organization Events | `GET /api/0/organizations/{org}/events/` | Discover events query with heavy Snuba fan-out | field_sets, datasets, per_page_values, sort_by |
+| Group Details | `GET /api/0/organizations/{org}/issues/{id}/` | Issue detail with optional latest-event sub-path; pre-fetches real issue IDs at startup | host (required), fetch_limit, detail_weight, latest_event_weight |
+| Organization Events Stats | `GET /api/0/organizations/{org}/events-stats/` | Time-series charting with expensive Snuba aggregations | y_axes, intervals, datasets |
+
+All tasks also accept: organization_slug, project_ids, and queries.

--- a/default_config/read_api.test.yml
+++ b/default_config/read_api.test.yml
@@ -2,24 +2,17 @@
 #
 # Before running, set these environment variables:
 #   AUTH_TOKEN  - API bearer token with read access
-#   API_HOST    - (only for GroupDetails) e.g. https://sentry.io
+#   API_HOST    - (only for GroupDetails) e.g. http://localhost:8000
 #
 # Or provide auth_token / host directly in the task params below.
 #
 # Each user class maps to one endpoint. Adjust `weight` to enable/disable
-# individual endpoints. Aggregate target rate is ~48 req/s (~10% of US
-# production read traffic).
-#
-# Usage:
-#   cp default_config/read_api.test.yml config/read_api.test.yml
-#   # edit config values
-#   locust -f read_api_locustfile.py
+# individual endpoints.
 
 users:
 
-  # Target: ~14 req/s (30% of total)
   OrganizationGroupIndex:
-    host: https://sentry.io
+    host: http://localhost:8000
     wait_time: constant(1)
     weight: 3
     tasks:
@@ -33,9 +26,8 @@ users:
         sort_options: ["date", "freq", "new", "trends"]
         queries: ["is:unresolved", ""]
 
-  # Target: ~12 req/s (25% of total)
   OrganizationEvents:
-    host: https://sentry.io
+    host: http://localhost:8000
     wait_time: constant(1)
     weight: 3
     tasks:
@@ -53,9 +45,8 @@ users:
         queries: ["", "event.type:error"]
         sort_by: ["-timestamp", "-count()"]
 
-  # Target: ~10 req/s (20% of total)
   GroupDetails:
-    host: https://sentry.io
+    host: http://localhost:8000
     wait_time: constant(1)
     weight: 2
     tasks:
@@ -64,14 +55,13 @@ users:
         auth_token: ${AUTH_TOKEN}
         organization_slug: your-org-slug
         # host is needed to pre-fetch issue IDs at startup
-        host: https://sentry.io
+        host: http://localhost:8000
         fetch_limit: 100
         detail_weight: 7
         latest_event_weight: 3
 
-  # Target: ~6 req/s (12% of total)
   OrganizationEventsStats:
-    host: https://sentry.io
+    host: http://localhost:8000
     wait_time: constant(1)
     weight: 1
     tasks:

--- a/default_config/read_api.test.yml
+++ b/default_config/read_api.test.yml
@@ -1,8 +1,8 @@
-# Load test configuration for Sentry's highest-traffic read API endpoints.
+# Load test configuration for highest-traffic read API endpoints.
 #
 # Before running, set these environment variables:
-#   SENTRY_AUTH_TOKEN  - Sentry API bearer token with read access
-#   SENTRY_API_HOST    - (only for GroupDetails) e.g. https://sentry.io
+#   AUTH_TOKEN  - API bearer token with read access
+#   API_HOST    - (only for GroupDetails) e.g. https://sentry.io
 #
 # Or provide auth_token / host directly in the task params below.
 #
@@ -11,7 +11,7 @@
 # production read traffic).
 #
 # Usage:
-#   cp default_config/sentry_read_api.test.yml config/sentry_read_api.test.yml
+#   cp default_config/read_api.test.yml config/read_api.test.yml
 #   # edit config values
 #   locust -f read_api_locustfile.py
 
@@ -25,10 +25,10 @@ users:
     tasks:
       organization_group_index_task_factory:
         weight: 1
-        auth_token: ${SENTRY_AUTH_TOKEN}
-        organization_slug: sentry
+        auth_token: ${AUTH_TOKEN}
+        organization_slug: your-org-slug
         # project_ids: [1234, 5678]
-        stats_periods: ["24h", "12h", "1h"]
+        stats_periods: ["90d", "24h", "12h", "1h"]
         limits: [25, 50, 100]
         sort_options: ["date", "freq", "new", "trends"]
         queries: ["is:unresolved", ""]
@@ -41,10 +41,10 @@ users:
     tasks:
       organization_events_task_factory:
         weight: 1
-        auth_token: ${SENTRY_AUTH_TOKEN}
-        organization_slug: sentry
+        auth_token: ${AUTH_TOKEN}
+        organization_slug: your-org-slug
         # project_ids: [1234, 5678]
-        stats_periods: ["24h", "12h", "1h"]
+        stats_periods: ["90d", "24h", "12h", "1h"]
         per_page_values: [10, 25, 50]
         field_sets:
           - ["title", "event.type", "project", "user.display", "timestamp"]
@@ -61,8 +61,8 @@ users:
     tasks:
       group_details_task_factory:
         weight: 1
-        auth_token: ${SENTRY_AUTH_TOKEN}
-        organization_slug: sentry
+        auth_token: ${AUTH_TOKEN}
+        organization_slug: your-org-slug
         # host is needed to pre-fetch issue IDs at startup
         host: https://sentry.io
         fetch_limit: 100
@@ -77,10 +77,10 @@ users:
     tasks:
       organization_events_stats_task_factory:
         weight: 1
-        auth_token: ${SENTRY_AUTH_TOKEN}
-        organization_slug: sentry
+        auth_token: ${AUTH_TOKEN}
+        organization_slug: your-org-slug
         # project_ids: [1234, 5678]
-        stats_periods: ["24h", "12h", "1h"]
+        stats_periods: ["90d", "24h", "12h", "1h"]
         y_axes:
           - ["count()"]
           - ["count()", "count_unique(user)"]

--- a/default_config/sentry_read_api.test.yml
+++ b/default_config/sentry_read_api.test.yml
@@ -31,7 +31,7 @@ users:
         # project_ids: [1234, 5678]
         stats_periods: ["24h", "12h", "1h"]
         limits: [25, 50, 100]
-        sort_options: ["date", "priority", "freq", "new"]
+        sort_options: ["date", "freq", "new", "trends"]
         queries: ["is:unresolved", ""]
 
   # Priority 2: Discover events - core query endpoint, heavy Snuba fan-out

--- a/default_config/sentry_read_api.test.yml
+++ b/default_config/sentry_read_api.test.yml
@@ -47,7 +47,7 @@ users:
         organization_slug: sentry
         # project_ids: [1234, 5678]
         stats_periods: ["24h", "12h", "1h"]
-        limits: [10, 25, 50]
+        per_page_values: [10, 25, 50]
         field_sets:
           - ["title", "event.type", "project", "user.display", "timestamp"]
           - ["title", "count()", "project"]

--- a/default_config/sentry_read_api.test.yml
+++ b/default_config/sentry_read_api.test.yml
@@ -1,0 +1,94 @@
+# Load test configuration for Sentry's highest-traffic read API endpoints.
+#
+# Before running, set these environment variables:
+#   SENTRY_AUTH_TOKEN  - Sentry API bearer token with read access
+#   SENTRY_API_HOST    - (only for GroupDetails) e.g. https://sentry.io
+#
+# Or provide auth_token / host directly in the task params below.
+#
+# Each user class maps to one endpoint. Adjust `weight` to enable/disable
+# individual endpoints. Aggregate target rate is ~48 req/s (~10% of US
+# production read traffic).
+#
+# Usage:
+#   cp default_config/sentry_read_api.test.yml config/sentry_read_api.test.yml
+#   # edit config values
+#   locust -f read_api_locustfile.py
+
+users:
+
+  # Priority 1: Issue list - highest volume AND latency (#1 Snuba search queries)
+  # Target: ~14 req/s (30% of total)
+  OrganizationGroupIndex:
+    host: https://sentry.io
+    wait_time: constant(1)
+    weight: 3
+    tasks:
+      organization_group_index_task_factory:
+        weight: 1
+        auth_token: ${SENTRY_AUTH_TOKEN}
+        organization_slug: sentry
+        # project_ids: [1234, 5678]
+        stats_periods: ["24h", "12h", "1h"]
+        limits: [25, 50, 100]
+        sort_options: ["date", "priority", "freq", "new"]
+        queries: ["is:unresolved", ""]
+
+  # Priority 2: Discover events - core query endpoint, heavy Snuba fan-out
+  # Target: ~12 req/s (25% of total)
+  OrganizationEvents:
+    host: https://sentry.io
+    wait_time: constant(1)
+    weight: 3
+    tasks:
+      organization_events_task_factory:
+        weight: 1
+        auth_token: ${SENTRY_AUTH_TOKEN}
+        organization_slug: sentry
+        # project_ids: [1234, 5678]
+        stats_periods: ["24h", "12h", "1h"]
+        limits: [10, 25, 50]
+        field_sets:
+          - ["title", "event.type", "project", "user.display", "timestamp"]
+          - ["title", "count()", "project"]
+        datasets: ["discover", "errors"]
+        queries: ["", "event.type:error"]
+        sort_by: ["-timestamp", "-count()"]
+
+  # Priority 3: Issue detail - mixed Postgres + Snuba
+  # Target: ~10 req/s (20% of total)
+  GroupDetails:
+    host: https://sentry.io
+    wait_time: constant(1)
+    weight: 2
+    tasks:
+      group_details_task_factory:
+        weight: 1
+        auth_token: ${SENTRY_AUTH_TOKEN}
+        organization_slug: sentry
+        # host is needed to pre-fetch issue IDs at startup
+        host: https://sentry.io
+        fetch_limit: 100
+        detail_weight: 7
+        latest_event_weight: 3
+
+  # Priority 4: Time-series charting - expensive Snuba aggregations
+  # Target: ~6 req/s (12% of total)
+  OrganizationEventsStats:
+    host: https://sentry.io
+    wait_time: constant(1)
+    weight: 1
+    tasks:
+      organization_events_stats_task_factory:
+        weight: 1
+        auth_token: ${SENTRY_AUTH_TOKEN}
+        organization_slug: sentry
+        # project_ids: [1234, 5678]
+        stats_periods: ["24h", "12h", "1h"]
+        y_axes:
+          - ["count()"]
+          - ["count()", "count_unique(user)"]
+          - ["p50(transaction.duration)", "p95(transaction.duration)"]
+        intervals: ["1h", "30m", "5m"]
+        queries: ["", "event.type:error"]
+        datasets: ["discover", "errors"]

--- a/default_config/sentry_read_api.test.yml
+++ b/default_config/sentry_read_api.test.yml
@@ -17,7 +17,6 @@
 
 users:
 
-  # Priority 1: Issue list - highest volume AND latency (#1 Snuba search queries)
   # Target: ~14 req/s (30% of total)
   OrganizationGroupIndex:
     host: https://sentry.io
@@ -34,7 +33,6 @@ users:
         sort_options: ["date", "freq", "new", "trends"]
         queries: ["is:unresolved", ""]
 
-  # Priority 2: Discover events - core query endpoint, heavy Snuba fan-out
   # Target: ~12 req/s (25% of total)
   OrganizationEvents:
     host: https://sentry.io
@@ -55,7 +53,6 @@ users:
         queries: ["", "event.type:error"]
         sort_by: ["-timestamp", "-count()"]
 
-  # Priority 3: Issue detail - mixed Postgres + Snuba
   # Target: ~10 req/s (20% of total)
   GroupDetails:
     host: https://sentry.io
@@ -72,7 +69,6 @@ users:
         detail_weight: 7
         latest_event_weight: 3
 
-  # Priority 4: Time-series charting - expensive Snuba aggregations
   # Target: ~6 req/s (12% of total)
   OrganizationEventsStats:
     host: https://sentry.io

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -19,9 +19,11 @@ def relay_address():
     host = relay_settings.get("host")
 
     if host is None:
-        raise ValueError("Missing relay.host settings from config file:{}".format(
-            _config_file_path()
-        ))
+        raise ValueError(
+            "Missing relay.host settings from config file:{}".format(
+                _config_file_path()
+            )
+        )
 
     return host
 

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -19,9 +19,9 @@ def relay_address():
     host = relay_settings.get("host")
 
     if host is None:
-        raise "Missing relay.host settings from config file:{}".format(
+        raise ValueError("Missing relay.host settings from config file:{}".format(
             _config_file_path()
-        )
+        ))
 
     return host
 

--- a/infrastructure/configurable_user.py
+++ b/infrastructure/configurable_user.py
@@ -98,7 +98,9 @@ def create_user_class(
 
     _wait_time = _get_wait_time(locust_info)
     if host is None:
-        _host = relay_address()
+        _host = locust_info.get("host")
+        if _host is None:
+            _host = relay_address()
     else:
         _host = host
 

--- a/infrastructure/configurable_user.py
+++ b/infrastructure/configurable_user.py
@@ -98,7 +98,9 @@ def create_user_class(
 
     _wait_time = _get_wait_time(locust_info)
     if host is None:
-        _host = locust_info.get("host")
+        # different user classes can point at different hosts, especially important for
+        # read APIs which target a different service than Relay
+        _host = locust_info.get("host") 
         if _host is None:
             _host = relay_address()
     else:

--- a/infrastructure/configurable_user.py
+++ b/infrastructure/configurable_user.py
@@ -100,7 +100,7 @@ def create_user_class(
     if host is None:
         # different user classes can point at different hosts, especially important for
         # read APIs which target a different service than Relay
-        _host = locust_info.get("host") 
+        _host = locust_info.get("host")
         if _host is None:
             _host = relay_address()
     else:

--- a/read_api_locustfile.py
+++ b/read_api_locustfile.py
@@ -1,0 +1,42 @@
+import resource
+
+# Raise the max number of open files
+current_limits = resource.getrlimit(resource.RLIMIT_NOFILE)
+new_limit = min(current_limits[1], 12000)
+resource.setrlimit(resource.RLIMIT_NOFILE, (new_limit, new_limit))
+
+from infrastructure import full_path_from_module_relative_path, create_user_class
+from tasks import event_tasks
+
+# Expose task factories so the YAML config can reference them by name.
+# Do NOT just import the functions in the module (you will get a warning that
+# the function is not used, you will remove it and then will get a runtime error).
+organization_group_index_task_factory = (
+    read_api_tasks.organization_group_index_task_factory
+)
+organization_events_task_factory = (
+    read_api_tasks.organization_events_task_factory
+)
+organization_events_stats_task_factory = (
+    read_api_tasks.organization_events_stats_task_factory
+)
+group_details_task_factory = (
+    read_api_tasks.group_details_task_factory
+)
+
+_config_path = full_path_from_module_relative_path(
+    __file__, "config/sentry_read_api.test.yml"
+)
+
+OrganizationGroupIndex = create_user_class(
+    "OrganizationGroupIndex", _config_path, __name__
+)
+OrganizationEvents = create_user_class(
+    "OrganizationEvents", _config_path, __name__
+)
+OrganizationEventsStats = create_user_class(
+    "OrganizationEventsStats", _config_path, __name__
+)
+GroupDetails = create_user_class(
+    "GroupDetails", _config_path, __name__
+)

--- a/read_api_locustfile.py
+++ b/read_api_locustfile.py
@@ -20,9 +20,7 @@ organization_events_stats_task_factory = (
 )
 group_details_task_factory = read_api_tasks.group_details_task_factory
 
-_config_path = full_path_from_module_relative_path(
-    __file__, "config/read_api.test.yml"
-)
+_config_path = full_path_from_module_relative_path(__file__, "config/read_api.test.yml")
 
 OrganizationGroupIndex = create_user_class(
     "OrganizationGroupIndex", _config_path, __name__

--- a/read_api_locustfile.py
+++ b/read_api_locustfile.py
@@ -14,15 +14,11 @@ from tasks import read_api_tasks
 organization_group_index_task_factory = (
     read_api_tasks.organization_group_index_task_factory
 )
-organization_events_task_factory = (
-    read_api_tasks.organization_events_task_factory
-)
+organization_events_task_factory = read_api_tasks.organization_events_task_factory
 organization_events_stats_task_factory = (
     read_api_tasks.organization_events_stats_task_factory
 )
-group_details_task_factory = (
-    read_api_tasks.group_details_task_factory
-)
+group_details_task_factory = read_api_tasks.group_details_task_factory
 
 _config_path = full_path_from_module_relative_path(
     __file__, "config/sentry_read_api.test.yml"
@@ -31,12 +27,8 @@ _config_path = full_path_from_module_relative_path(
 OrganizationGroupIndex = create_user_class(
     "OrganizationGroupIndex", _config_path, __name__
 )
-OrganizationEvents = create_user_class(
-    "OrganizationEvents", _config_path, __name__
-)
+OrganizationEvents = create_user_class("OrganizationEvents", _config_path, __name__)
 OrganizationEventsStats = create_user_class(
     "OrganizationEventsStats", _config_path, __name__
 )
-GroupDetails = create_user_class(
-    "GroupDetails", _config_path, __name__
-)
+GroupDetails = create_user_class("GroupDetails", _config_path, __name__)

--- a/read_api_locustfile.py
+++ b/read_api_locustfile.py
@@ -6,7 +6,7 @@ new_limit = min(current_limits[1], 12000)
 resource.setrlimit(resource.RLIMIT_NOFILE, (new_limit, new_limit))
 
 from infrastructure import full_path_from_module_relative_path, create_user_class
-from tasks import event_tasks
+from tasks import read_api_tasks
 
 # Expose task factories so the YAML config can reference them by name.
 # Do NOT just import the functions in the module (you will get a warning that

--- a/read_api_locustfile.py
+++ b/read_api_locustfile.py
@@ -21,7 +21,7 @@ organization_events_stats_task_factory = (
 group_details_task_factory = read_api_tasks.group_details_task_factory
 
 _config_path = full_path_from_module_relative_path(
-    __file__, "config/sentry_read_api.test.yml"
+    __file__, "config/read_api.test.yml"
 )
 
 OrganizationGroupIndex = create_user_class(

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -108,7 +108,7 @@ def organization_events_task_factory(task_params=None):
     org_slug = task_params.get("organization_slug", "sentry")
     project_ids = task_params.get("project_ids", [])
     stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
-    limits = task_params.get("limits", [10, 25, 50])
+    per_page_values = task_params.get("per_page_values", [10, 25, 50])
     field_sets = task_params.get(
         "field_sets",
         [
@@ -130,7 +130,7 @@ def organization_events_task_factory(task_params=None):
         params = [("field", f) for f in fields]
 
         params.append(("statsPeriod", _choice(stats_periods, "24h")))
-        params.append(("limit", _choice(limits, 10)))
+        params.append(("per_page", _choice(per_page_values, 10)))
 
         dataset = _choice(datasets, "")
         if dataset:

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -21,10 +21,10 @@ def _resolve_env_var(value):
 def _get_auth_token(task_params):
     token = _resolve_env_var(task_params.get("auth_token", ""))
     if not token:
-        token = os.environ.get("SENTRY_AUTH_TOKEN")
+        token = os.environ.get("AUTH_TOKEN")
     if not token:
         raise ValueError(
-            "auth_token is required. Set it in task params or SENTRY_AUTH_TOKEN env var."
+            "auth_token is required. Set it in task params or AUTH_TOKEN env var."
         )
     return token
 
@@ -214,9 +214,9 @@ def group_details_task_factory(task_params=None):
     auth_token = _get_auth_token(task_params)
     org_slug = task_params.get("organization_slug", "sentry")
     # host is needed to pre-fetch issue IDs outside of Locust's client.
-    # Prefer setting it in the YAML task params; SENTRY_API_HOST is a fallback.
+    # Prefer setting it in the YAML task params; API_HOST is a fallback.
     host = _resolve_env_var(task_params.get("host", "")) or os.environ.get(
-        "SENTRY_API_HOST"
+        "API_HOST"
     )
     fetch_limit = task_params.get("fetch_limit", 100)
     detail_weight = task_params.get("detail_weight", 1)
@@ -264,7 +264,7 @@ def _fetch_issue_ids(host, auth_token, org_slug, limit):
     if not host:
         raise ValueError(
             "host is required for group_details to fetch issue IDs. "
-            "Set it in task params or SENTRY_API_HOST env var."
+            "Set it in task params or API_HOST env var."
         )
 
     url = f"{host.rstrip('/')}/api/0/organizations/{org_slug}/issues/"

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -1,11 +1,5 @@
 """
 Task factories for load-testing Sentry's highest-traffic read API endpoints.
-
-Based on Datadog profiling data, these are the top 4 read endpoints by volume:
-  1. organization_group_index  (~4,185 req/s, p95=1,550ms) - Issue list / Snuba search
-  2. organization_events       (~3,498 req/s, p95=340ms)   - Discover events query
-  3. group_details             (~2,908 req/s, p95=650ms)   - Issue detail (Postgres+Snuba)
-  4. organization_events_stats (~1,688 req/s, p95=451ms)   - Time-series charting
 """
 
 import logging

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -68,7 +68,7 @@ def organization_group_index_task_factory(task_params=None):
     project_ids = task_params.get("project_ids", [])
     stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
     limits = task_params.get("limits", [25, 50, 100])
-    sort_options = task_params.get("sort_options", ["date", "priority", "freq", "new"])
+    sort_options = task_params.get("sort_options", ["date", "freq", "new", "trends"])
     queries = task_params.get("queries", ["is:unresolved", ""])
 
     base_path = f"/api/0/organizations/{org_slug}/issues/"

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -124,9 +124,7 @@ def organization_events_task_factory(task_params=None):
     headers = _read_headers(auth_token)
 
     def inner(user):
-        fields = _choice(
-            field_sets, ["title", "event.type", "project", "timestamp"]
-        )
+        fields = _choice(field_sets, ["title", "event.type", "project", "timestamp"])
         params = [("field", f) for f in fields]
 
         params.append(("statsPeriod", _choice(stats_periods, "24h")))
@@ -241,9 +239,7 @@ def group_details_task_factory(task_params=None):
 
     headers = _read_headers(auth_token)
     detail_name = f"/api/0/organizations/{org_slug}/issues/{{id}}/"
-    latest_event_name = (
-        f"/api/0/organizations/{org_slug}/issues/{{id}}/events/latest/"
-    )
+    latest_event_name = f"/api/0/organizations/{org_slug}/issues/{{id}}/events/latest/"
 
     def inner(user):
         issue_id = random.choice(issue_ids)
@@ -281,9 +277,7 @@ def _fetch_issue_ids(host, auth_token, org_slug, limit):
     headers = _read_headers(auth_token)
 
     try:
-        resp = requests.get(
-            url, headers=headers, params={"limit": limit}, timeout=30
-        )
+        resp = requests.get(url, headers=headers, params={"limit": limit}, timeout=30)
         resp.raise_for_status()
         issues = resp.json()
         return [str(issue["id"]) for issue in issues]

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -1,0 +1,292 @@
+"""
+Task factories for load-testing Sentry's highest-traffic read API endpoints.
+
+Based on Datadog profiling data, these are the top 4 read endpoints by volume:
+  1. organization_group_index  (~4,185 req/s, p95=1,550ms) - Issue list / Snuba search
+  2. organization_events       (~3,498 req/s, p95=340ms)   - Discover events query
+  3. group_details             (~2,908 req/s, p95=650ms)   - Issue detail (Postgres+Snuba)
+  4. organization_events_stats (~1,688 req/s, p95=451ms)   - Time-series charting
+"""
+
+import logging
+import os
+import random
+from urllib.parse import urlencode
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_env_var(value):
+    if isinstance(value, str) and value.startswith("${") and value.endswith("}"):
+        return os.environ.get(value[2:-1])
+    return value
+
+
+def _get_auth_token(task_params):
+    token = _resolve_env_var(task_params.get("auth_token", ""))
+    if not token:
+        token = os.environ.get("SENTRY_AUTH_TOKEN")
+    if not token:
+        raise ValueError(
+            "auth_token is required. Set it in task params or SENTRY_AUTH_TOKEN env var."
+        )
+    return token
+
+
+def _read_headers(auth_token):
+    return {
+        "Authorization": f"Bearer {auth_token}",
+        "Content-Type": "application/json",
+    }
+
+
+def _build_query_url(base_path, params):
+    if not params:
+        return base_path
+    return f"{base_path}?{urlencode(params)}"
+
+
+def _choice(choices, fallback):
+    if choices:
+        return random.choice(choices)
+    return fallback
+
+
+def organization_group_index_task_factory(task_params=None):
+    """
+    Issues list endpoint: GET /api/0/organizations/{org}/issues/
+
+    Randomizes statsPeriod, sort, query, limit, and optional project filter per request.
+    """
+    if task_params is None:
+        task_params = {}
+
+    auth_token = _get_auth_token(task_params)
+    org_slug = task_params.get("organization_slug", "sentry")
+    project_ids = task_params.get("project_ids", [])
+    stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
+    limits = task_params.get("limits", [25, 50, 100])
+    sort_options = task_params.get("sort_options", ["date", "priority", "freq", "new"])
+    queries = task_params.get("queries", ["is:unresolved", ""])
+
+    base_path = f"/api/0/organizations/{org_slug}/issues/"
+    headers = _read_headers(auth_token)
+
+    def inner(user):
+        params = [
+            ("statsPeriod", _choice(stats_periods, "24h")),
+            ("sort", _choice(sort_options, "date")),
+            ("limit", _choice(limits, 25)),
+        ]
+
+        query = _choice(queries, "is:unresolved")
+        if query:
+            params.append(("query", query))
+
+        if project_ids:
+            params.append(("project", random.choice(project_ids)))
+
+        url = _build_query_url(base_path, params)
+        return user.client.get(url, headers=headers, name=base_path)
+
+    return inner
+
+
+def organization_events_task_factory(task_params=None):
+    """
+    Discover events endpoint: GET /api/0/organizations/{org}/events/
+
+    Randomizes field sets, dataset, query, sort, and project filter per request.
+    Each field in the chosen field set is added as a separate `field` query param.
+    """
+    if task_params is None:
+        task_params = {}
+
+    auth_token = _get_auth_token(task_params)
+    org_slug = task_params.get("organization_slug", "sentry")
+    project_ids = task_params.get("project_ids", [])
+    stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
+    limits = task_params.get("limits", [10, 25, 50])
+    field_sets = task_params.get(
+        "field_sets",
+        [
+            ["title", "event.type", "project", "user.display", "timestamp"],
+            ["title", "count()", "project"],
+        ],
+    )
+    datasets = task_params.get("datasets", ["discover", "errors"])
+    queries = task_params.get("queries", ["", "event.type:error"])
+    sort_by = task_params.get("sort_by", ["-timestamp", "-count()"])
+
+    base_path = f"/api/0/organizations/{org_slug}/events/"
+    headers = _read_headers(auth_token)
+
+    def inner(user):
+        fields = _choice(
+            field_sets, ["title", "event.type", "project", "timestamp"]
+        )
+        params = [("field", f) for f in fields]
+
+        params.append(("statsPeriod", _choice(stats_periods, "24h")))
+        params.append(("limit", _choice(limits, 10)))
+
+        dataset = _choice(datasets, "")
+        if dataset:
+            params.append(("dataset", dataset))
+
+        query = _choice(queries, "")
+        if query:
+            params.append(("query", query))
+
+        sort = _choice(sort_by, "")
+        if sort:
+            params.append(("sort", sort))
+
+        if project_ids:
+            params.append(("project", random.choice(project_ids)))
+
+        url = _build_query_url(base_path, params)
+        return user.client.get(url, headers=headers, name=base_path)
+
+    return inner
+
+
+def organization_events_stats_task_factory(task_params=None):
+    """
+    Time-series charting endpoint: GET /api/0/organizations/{org}/events-stats/
+
+    Randomizes yAxis set, statsPeriod, interval, query, dataset, and project filter.
+    Each yAxis in the chosen set is added as a separate `yAxis` query param.
+    """
+    if task_params is None:
+        task_params = {}
+
+    auth_token = _get_auth_token(task_params)
+    org_slug = task_params.get("organization_slug", "sentry")
+    project_ids = task_params.get("project_ids", [])
+    stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
+    y_axes = task_params.get(
+        "y_axes",
+        [
+            ["count()"],
+            ["count()", "count_unique(user)"],
+            ["p50(transaction.duration)", "p95(transaction.duration)"],
+        ],
+    )
+    intervals = task_params.get("intervals", ["1h", "30m", "5m"])
+    queries = task_params.get("queries", ["", "event.type:error"])
+    datasets = task_params.get("datasets", ["discover", "errors"])
+
+    base_path = f"/api/0/organizations/{org_slug}/events-stats/"
+    headers = _read_headers(auth_token)
+
+    def inner(user):
+        y_axis_set = _choice(y_axes, ["count()"])
+        params = [("yAxis", y) for y in y_axis_set]
+
+        params.append(("statsPeriod", _choice(stats_periods, "24h")))
+        params.append(("interval", _choice(intervals, "1h")))
+
+        query = _choice(queries, "")
+        if query:
+            params.append(("query", query))
+
+        dataset = _choice(datasets, "")
+        if dataset:
+            params.append(("dataset", dataset))
+
+        if project_ids:
+            params.append(("project", random.choice(project_ids)))
+
+        url = _build_query_url(base_path, params)
+        return user.client.get(url, headers=headers, name=base_path)
+
+    return inner
+
+
+def group_details_task_factory(task_params=None):
+    """
+    Issue detail endpoint with two sub-paths:
+      - Detail:       GET /api/0/organizations/{org}/issues/{id}/
+      - Latest event: GET /api/0/organizations/{org}/issues/{id}/events/latest/
+
+    At construction time, fetches real issue IDs from the issues endpoint to avoid
+    hardcoding. Uses weighted randomization to choose between detail and latest-event
+    paths per request.
+    """
+    if task_params is None:
+        task_params = {}
+
+    auth_token = _get_auth_token(task_params)
+    org_slug = task_params.get("organization_slug", "sentry")
+    # host is needed to pre-fetch issue IDs outside of Locust's client.
+    # Prefer setting it in the YAML task params; SENTRY_API_HOST is a fallback.
+    host = _resolve_env_var(task_params.get("host", "")) or os.environ.get(
+        "SENTRY_API_HOST"
+    )
+    fetch_limit = task_params.get("fetch_limit", 100)
+    detail_weight = task_params.get("detail_weight", 1)
+    latest_event_weight = task_params.get("latest_event_weight", 0)
+
+    issue_ids = _fetch_issue_ids(host, auth_token, org_slug, fetch_limit)
+    if not issue_ids:
+        raise ValueError(
+            f"Failed to fetch issue IDs for org '{org_slug}'. "
+            f"Ensure host (got: {host!r}) and auth_token are correct."
+        )
+
+    logger.info("Fetched %d issue IDs for group_details", len(issue_ids))
+
+    headers = _read_headers(auth_token)
+    detail_name = f"/api/0/organizations/{org_slug}/issues/{{id}}/"
+    latest_event_name = (
+        f"/api/0/organizations/{org_slug}/issues/{{id}}/events/latest/"
+    )
+
+    def inner(user):
+        issue_id = random.choice(issue_ids)
+
+        if latest_event_weight > 0 and detail_weight > 0:
+            use_latest = random.choices(
+                [False, True],
+                weights=[detail_weight, latest_event_weight],
+            )[0]
+        elif latest_event_weight > 0:
+            use_latest = True
+        else:
+            use_latest = False
+
+        if use_latest:
+            path = f"/api/0/organizations/{org_slug}/issues/{issue_id}/events/latest/"
+            name = latest_event_name
+        else:
+            path = f"/api/0/organizations/{org_slug}/issues/{issue_id}/"
+            name = detail_name
+
+        return user.client.get(path, headers=headers, name=name)
+
+    return inner
+
+
+def _fetch_issue_ids(host, auth_token, org_slug, limit):
+    if not host:
+        raise ValueError(
+            "host is required for group_details to fetch issue IDs. "
+            "Set it in task params or SENTRY_API_HOST env var."
+        )
+
+    url = f"{host.rstrip('/')}/api/0/organizations/{org_slug}/issues/"
+    headers = _read_headers(auth_token)
+
+    try:
+        resp = requests.get(
+            url, headers=headers, params={"limit": limit}, timeout=30
+        )
+        resp.raise_for_status()
+        issues = resp.json()
+        return [str(issue["id"]) for issue in issues]
+    except Exception as e:
+        logger.error("Failed to fetch issue IDs from %s: %s", url, e)
+        return []

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -215,9 +215,7 @@ def group_details_task_factory(task_params=None):
     org_slug = task_params.get("organization_slug", "sentry")
     # host is needed to pre-fetch issue IDs outside of Locust's client.
     # Prefer setting it in the YAML task params; API_HOST is a fallback.
-    host = _resolve_env_var(task_params.get("host", "")) or os.environ.get(
-        "API_HOST"
-    )
+    host = _resolve_env_var(task_params.get("host", "")) or os.environ.get("API_HOST")
     fetch_limit = task_params.get("fetch_limit", 100)
     detail_weight = task_params.get("detail_weight", 1)
     latest_event_weight = task_params.get("latest_event_weight", 0)

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -88,6 +88,11 @@ def organization_group_index_task_factory(task_params=None):
     return inner
 
 
+def _is_sort_in_fields(sort_key, fields):
+    bare = sort_key.lstrip("-")
+    return bare in fields or bare == "timestamp"
+
+
 def organization_events_task_factory(task_params=None):
     """
     Discover events endpoint: GET /api/0/organizations/{org}/events/
@@ -132,7 +137,9 @@ def organization_events_task_factory(task_params=None):
         if query:
             params.append(("query", query))
 
-        sort = _choice(sort_by, "")
+        # we can't sort by an aggregate (e.g. -count()) not present in fields
+        valid_sorts = [s for s in sort_by if _is_sort_in_fields(s, fields)]
+        sort = _choice(valid_sorts, "") if valid_sorts else ""
         if sort:
             params.append(("sort", sort))
 
@@ -174,8 +181,23 @@ def organization_events_stats_task_factory(task_params=None):
     base_path = f"/api/0/organizations/{org_slug}/events-stats/"
     headers = _read_headers(auth_token)
 
+    # transaction.duration metrics aren't available on the "errors" dataset
+    _transaction_y_axes = {
+        "p50(transaction.duration)",
+        "p95(transaction.duration)",
+        "p99(transaction.duration)",
+        "avg(transaction.duration)",
+    }
+
+    def _is_y_axis_compatible(y_axis_set, dataset):
+        if dataset != "errors":
+            return True
+        return not any(y in _transaction_y_axes for y in y_axis_set)
+
     def inner(user):
-        y_axis_set = _choice(y_axes, ["count()"])
+        dataset = _choice(datasets, "")
+        compatible = [ys for ys in y_axes if _is_y_axis_compatible(ys, dataset)]
+        y_axis_set = _choice(compatible, ["count()"]) if compatible else ["count()"]
         params = [("yAxis", y) for y in y_axis_set]
 
         params.append(("statsPeriod", _choice(stats_periods, "24h")))
@@ -185,7 +207,6 @@ def organization_events_stats_task_factory(task_params=None):
         if query:
             params.append(("query", query))
 
-        dataset = _choice(datasets, "")
         if dataset:
             params.append(("dataset", dataset))
 

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -90,7 +90,7 @@ def organization_group_index_task_factory(task_params=None):
 
 def _is_sort_in_fields(sort_key, fields):
     bare = sort_key.lstrip("-")
-    return bare in fields or bare == "timestamp"
+    return bare in fields
 
 
 def organization_events_task_factory(task_params=None):

--- a/tests/test_read_api_tasks.py
+++ b/tests/test_read_api_tasks.py
@@ -170,7 +170,7 @@ class TestOrganizationEvents:
                 "organization_slug": "myorg",
                 "field_sets": [["title", "count()", "project"]],
                 "stats_periods": ["24h"],
-                "limits": [10],
+                "per_page_values": [10],
                 "datasets": [""],
                 "queries": [""],
                 "sort_by": [""],
@@ -191,7 +191,7 @@ class TestOrganizationEvents:
                 "datasets": ["discover"],
                 "field_sets": [["title"]],
                 "stats_periods": ["1h"],
-                "limits": [10],
+                "per_page_values": [10],
                 "queries": [""],
                 "sort_by": [""],
             }

--- a/tests/test_read_api_tasks.py
+++ b/tests/test_read_api_tasks.py
@@ -134,9 +134,7 @@ class TestOrganizationGroupIndex:
         assert call_args[1]["name"] == "/api/0/organizations/myorg/issues/"
 
     def test_bearer_auth_header(self):
-        task = organization_group_index_task_factory(
-            {"auth_token": "secret"}
-        )
+        task = organization_group_index_task_factory({"auth_token": "secret"})
         user = _make_mock_user()
         task(user)
 

--- a/tests/test_read_api_tasks.py
+++ b/tests/test_read_api_tasks.py
@@ -1,0 +1,343 @@
+import os
+from collections import Counter
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tasks.read_api_tasks import (
+    _build_query_url,
+    _choice,
+    _fetch_issue_ids,
+    _get_auth_token,
+    _read_headers,
+    _resolve_env_var,
+    group_details_task_factory,
+    organization_events_stats_task_factory,
+    organization_events_task_factory,
+    organization_group_index_task_factory,
+)
+
+
+class TestHelpers:
+    def test_resolve_env_var_plain_string(self):
+        assert _resolve_env_var("my-token") == "my-token"
+
+    def test_resolve_env_var_from_env(self, monkeypatch):
+        monkeypatch.setenv("MY_TOKEN", "secret123")
+        assert _resolve_env_var("${MY_TOKEN}") == "secret123"
+
+    def test_resolve_env_var_missing(self, monkeypatch):
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        assert _resolve_env_var("${MISSING_VAR}") is None
+
+    def test_get_auth_token_from_params(self):
+        assert _get_auth_token({"auth_token": "tok123"}) == "tok123"
+
+    def test_get_auth_token_from_env(self, monkeypatch):
+        monkeypatch.setenv("SENTRY_AUTH_TOKEN", "env-tok")
+        assert _get_auth_token({}) == "env-tok"
+
+    def test_get_auth_token_env_var_syntax(self, monkeypatch):
+        monkeypatch.setenv("MY_TOK", "resolved")
+        assert _get_auth_token({"auth_token": "${MY_TOK}"}) == "resolved"
+
+    def test_get_auth_token_missing_raises(self, monkeypatch):
+        monkeypatch.delenv("SENTRY_AUTH_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="auth_token is required"):
+            _get_auth_token({})
+
+    def test_read_headers(self):
+        headers = _read_headers("tok")
+        assert headers["Authorization"] == "Bearer tok"
+
+    def test_build_query_url_no_params(self):
+        assert _build_query_url("/api/0/issues/", []) == "/api/0/issues/"
+        assert _build_query_url("/api/0/issues/", None) == "/api/0/issues/"
+
+    def test_build_query_url_with_params(self):
+        url = _build_query_url("/api/0/issues/", [("limit", 25), ("sort", "date")])
+        assert url == "/api/0/issues/?limit=25&sort=date"
+
+    def test_build_query_url_multi_value(self):
+        url = _build_query_url(
+            "/api/0/events/", [("field", "title"), ("field", "count()")]
+        )
+        assert url == "/api/0/events/?field=title&field=count%28%29"
+
+    def test_choice_with_values(self):
+        assert _choice(["a"], "z") == "a"
+
+    def test_choice_empty_returns_fallback(self):
+        assert _choice([], "z") == "z"
+        assert _choice(None, "z") == "z"
+
+
+class TestFetchIssueIds:
+    def test_missing_host_raises(self):
+        with pytest.raises(ValueError, match="host is required"):
+            _fetch_issue_ids(None, "tok", "sentry", 100)
+
+    @patch("tasks.read_api_tasks.requests.get")
+    def test_successful_fetch(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [{"id": 1}, {"id": 2}, {"id": 3}]
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        ids = _fetch_issue_ids("https://sentry.io", "tok", "sentry", 100)
+        assert ids == ["1", "2", "3"]
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        assert "sentry.io/api/0/organizations/sentry/issues/" in call_args[0][0]
+
+    @patch("tasks.read_api_tasks.requests.get")
+    def test_http_error_returns_empty(self, mock_get):
+        mock_get.side_effect = Exception("connection refused")
+        ids = _fetch_issue_ids("https://sentry.io", "tok", "sentry", 100)
+        assert ids == []
+
+
+def _make_mock_user():
+    user = MagicMock()
+    user.client.get.return_value = MagicMock(status_code=200)
+    return user
+
+
+class TestOrganizationGroupIndex:
+    def test_factory_returns_callable(self):
+        task = organization_group_index_task_factory(
+            {"auth_token": "tok", "organization_slug": "myorg"}
+        )
+        assert callable(task)
+
+    def test_request_url_structure(self):
+        task = organization_group_index_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "stats_periods": ["1h"],
+                "limits": [25],
+                "sort_options": ["date"],
+                "queries": ["is:unresolved"],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        call_args = user.client.get.call_args
+        url = call_args[0][0]
+        assert url.startswith("/api/0/organizations/myorg/issues/")
+        assert "statsPeriod=1h" in url
+        assert "sort=date" in url
+        assert "limit=25" in url
+        assert "query=is%3Aunresolved" in url
+        assert call_args[1]["name"] == "/api/0/organizations/myorg/issues/"
+
+    def test_bearer_auth_header(self):
+        task = organization_group_index_task_factory(
+            {"auth_token": "secret"}
+        )
+        user = _make_mock_user()
+        task(user)
+
+        headers = user.client.get.call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer secret"
+
+    def test_project_filter(self):
+        task = organization_group_index_task_factory(
+            {
+                "auth_token": "tok",
+                "project_ids": [42],
+                "queries": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "project=42" in url
+
+
+class TestOrganizationEvents:
+    def test_factory_returns_callable(self):
+        task = organization_events_task_factory({"auth_token": "tok"})
+        assert callable(task)
+
+    def test_multi_value_fields(self):
+        task = organization_events_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "field_sets": [["title", "count()", "project"]],
+                "stats_periods": ["24h"],
+                "limits": [10],
+                "datasets": [""],
+                "queries": [""],
+                "sort_by": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "field=title" in url
+        assert "field=count" in url
+        assert "field=project" in url
+
+    def test_optional_dataset(self):
+        task = organization_events_task_factory(
+            {
+                "auth_token": "tok",
+                "datasets": ["discover"],
+                "field_sets": [["title"]],
+                "stats_periods": ["1h"],
+                "limits": [10],
+                "queries": [""],
+                "sort_by": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "dataset=discover" in url
+
+
+class TestOrganizationEventsStats:
+    def test_factory_returns_callable(self):
+        task = organization_events_stats_task_factory({"auth_token": "tok"})
+        assert callable(task)
+
+    def test_multi_value_yaxis(self):
+        task = organization_events_stats_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "y_axes": [["count()", "count_unique(user)"]],
+                "stats_periods": ["24h"],
+                "intervals": ["1h"],
+                "queries": [""],
+                "datasets": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert url.startswith("/api/0/organizations/myorg/events-stats/")
+        assert "yAxis=count" in url
+        assert "yAxis=count_unique" in url
+
+    def test_interval_param(self):
+        task = organization_events_stats_task_factory(
+            {
+                "auth_token": "tok",
+                "y_axes": [["count()"]],
+                "stats_periods": ["12h"],
+                "intervals": ["30m"],
+                "queries": [""],
+                "datasets": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "interval=30m" in url
+        assert "statsPeriod=12h" in url
+
+
+class TestGroupDetails:
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_factory_returns_callable(self, mock_fetch):
+        mock_fetch.return_value = ["111", "222"]
+        task = group_details_task_factory(
+            {"auth_token": "tok", "host": "https://sentry.io"}
+        )
+        assert callable(task)
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_detail_url(self, mock_fetch):
+        mock_fetch.return_value = ["42"]
+        task = group_details_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "host": "https://sentry.io",
+                "detail_weight": 1,
+                "latest_event_weight": 0,
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert url == "/api/0/organizations/myorg/issues/42/"
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_latest_event_url(self, mock_fetch):
+        mock_fetch.return_value = ["42"]
+        task = group_details_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "host": "https://sentry.io",
+                "detail_weight": 0,
+                "latest_event_weight": 1,
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert url == "/api/0/organizations/myorg/issues/42/events/latest/"
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_weighted_distribution(self, mock_fetch):
+        mock_fetch.return_value = ["1"]
+        task = group_details_task_factory(
+            {
+                "auth_token": "tok",
+                "host": "https://sentry.io",
+                "detail_weight": 7,
+                "latest_event_weight": 3,
+            }
+        )
+        user = _make_mock_user()
+
+        counts = Counter()
+        for _ in range(1000):
+            task(user)
+            url = user.client.get.call_args[0][0]
+            if "events/latest" in url:
+                counts["latest"] += 1
+            else:
+                counts["detail"] += 1
+
+        assert 200 < counts["latest"] < 400
+        assert 600 < counts["detail"] < 800
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_no_issue_ids_raises(self, mock_fetch):
+        mock_fetch.return_value = []
+        with pytest.raises(ValueError, match="Failed to fetch issue IDs"):
+            group_details_task_factory(
+                {"auth_token": "tok", "host": "https://sentry.io"}
+            )
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_name_param_uses_template(self, mock_fetch):
+        mock_fetch.return_value = ["99"]
+        task = group_details_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "sentry",
+                "host": "https://sentry.io",
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        name = user.client.get.call_args[1]["name"]
+        assert "{id}" in name
+        assert "99" not in name

--- a/tests/test_read_api_tasks.py
+++ b/tests/test_read_api_tasks.py
@@ -34,7 +34,7 @@ class TestHelpers:
         assert _get_auth_token({"auth_token": "tok123"}) == "tok123"
 
     def test_get_auth_token_from_env(self, monkeypatch):
-        monkeypatch.setenv("SENTRY_AUTH_TOKEN", "env-tok")
+        monkeypatch.setenv("AUTH_TOKEN", "env-tok")
         assert _get_auth_token({}) == "env-tok"
 
     def test_get_auth_token_env_var_syntax(self, monkeypatch):
@@ -42,7 +42,7 @@ class TestHelpers:
         assert _get_auth_token({"auth_token": "${MY_TOK}"}) == "resolved"
 
     def test_get_auth_token_missing_raises(self, monkeypatch):
-        monkeypatch.delenv("SENTRY_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("AUTH_TOKEN", raising=False)
         with pytest.raises(ValueError, match="auth_token is required"):
             _get_auth_token({})
 


### PR DESCRIPTION
4 new test types targeting Sentry's highest-traffic read/query API endpoints
Choice of endpoints was based on the profiling dashboard here: https://app.datadoghq.com/dashboard/66w-593-ysx, along with some qualitative analysis. Claude formatted the outcomes into a nice table 🤖, I chose to start with the top 4 test types before committing to the remainder.

results of a local 1m test:
<img width="1176" height="513" alt="Screenshot 2026-05-07 at 10 25 39 AM" src="https://github.com/user-attachments/assets/f2f8346c-9337-403c-85e6-7a43702df0c6" />


| Priority | Endpoint                         | Avg Volume | p95 (ms) | Rationale                                                                                          |
|----------|----------------------------------|-----------|----------|----------------------------------------------------------------------------------------------------|
| 1        | organization_group_index         | 4,185     | 1,550    | #1 volume AND #1 latency. The issue list -- heavy Snuba search queries. Must be in any load test.  |
| 2        | organization_events              | 3,498     | 340      | #2 volume. Core Discover/events query endpoint. Heavy Snuba fan-out.                               |
| 3        | group_details                    | 2,908     | 650      | #3 volume among data endpoints. Issue detail page -- mixed Postgres + Snuba.                       |
| 4        | organization_events_stats        | 1,688     | 451      | Time-series charting endpoint. Expensive Snuba aggregations, high volume.                          |
| 5        | group_event_details              | 1,490     | 508      | Core issue detail event view. Moderate volume with meaningful latency.                             |
| 6        | organization_tags                | 2,160     | 284      | High volume. Powers filter dropdowns across the UI -- called on nearly every page.                 |
| 7        | group_events                     | lower     | 1,480    | 2nd highest latency of any endpoint. Long connection hold = resource risk under load.              |
| 8        | organization_releases            | 1,400     | 614      | High latency release listing. Hits Postgres heavily.                                               |
| 9        | project_group_index              | moderate  | 1,043    | Project-scoped issue list. 3rd highest latency. Same Snuba search path as #1.                     |
| 10       | organization_group_index_stats   | 808       | 646      | Companion to issue list (#1). Fired alongside it -- adds to combined page load pressure.           |

I also had Claude attempt to write me a one-off "how-to" guide on running these tests, [check it out here](https://docs.google.com/document/d/1teC2HNWHAwAggun4X-oar38aWW7ZzIFoDb5J4-fgjV0/edit?tab=t.0#heading=h.pber5s80okvy) - opted not to update the README with anything significant until we actually give it a shot in prod