### PR TITLE
feat: add Sentry read API load test types for P1 endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,23 @@ jobs:
 
       - name: Run Black
         run: uv run black --check .
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+        with:
+          version: '0.8.2'
+          enable-cache: false
+
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
+        with:
+          cache-dependency-path: uv.lock
+          install-cmd: uv sync
+
+      - name: Run tests
+        run: uv run pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -265,5 +265,11 @@ read access.
 | Organization Events | `GET /api/0/organizations/{org}/events/` | Discover events query with heavy Snuba fan-out | field_sets, datasets, per_page_values, sort_by |
 | Group Details | `GET /api/0/organizations/{org}/issues/{id}/` | Issue detail with optional latest-event sub-path; pre-fetches real issue IDs at startup | host (required), fetch_limit, detail_weight, latest_event_weight |
 | Organization Events Stats | `GET /api/0/organizations/{org}/events-stats/` | Time-series charting with expensive Snuba aggregations | y_axes, intervals, datasets |
+| Group Event Details | `GET /api/0/organizations/{org}/issues/{id}/events/{event_id}/` | Issue event detail view; pre-fetches issue IDs, uses latest/oldest/recommended | host (required), fetch_limit, event_id_types |
+| Organization Tags | `GET /api/0/organizations/{org}/tags/` | Filter dropdown tags — called on nearly every page | stats_periods, datasets |
+| Group Events | `GET /api/0/organizations/{org}/issues/{id}/events/` | Issue events list — 2nd highest latency endpoint; pre-fetches issue IDs | host (required), fetch_limit, full_options, per_page_values |
+| Organization Releases | `GET /api/0/organizations/{org}/releases/` | Release listing with health stats | per_page_values, sort_options, health_stat_options |
+| Project Group Index | `GET /api/0/projects/{org}/{project_slug}/issues/` | Project-scoped issue list — same Snuba search path | project_slugs (required), limits, sort_options |
+| Organization Group Index Stats | `GET /api/0/organizations/{org}/issues-stats/` | Companion to issue list — fetches sparkline stats in batches | host (required), fetch_limit, batch_size |
 
 All tasks also accept: organization_slug, project_ids, and queries.

--- a/default_config/read_api.test.yml
+++ b/default_config/read_api.test.yml
@@ -2,7 +2,7 @@
 #
 # Before running, set these environment variables:
 #   AUTH_TOKEN  - API bearer token with read access
-#   API_HOST    - (only for GroupDetails) e.g. http://localhost:8000
+#   API_HOST    - (for endpoints that pre-fetch issue IDs) e.g. http://localhost:8000
 #
 # Or provide auth_token / host directly in the task params below.
 #
@@ -78,3 +78,99 @@ users:
         intervals: ["1h", "30m", "5m"]
         queries: ["", "event.type:error"]
         datasets: ["discover", "errors"]
+
+  # Priority #5 - Issue event detail, 1,490 req/s in prod
+  GroupEventDetails:
+    host: http://localhost:8000
+    wait_time: constant(1)
+    weight: 1
+    tasks:
+      group_event_details_task_factory:
+        weight: 1
+        auth_token: ${AUTH_TOKEN}
+        organization_slug: your-org-slug
+        host: http://localhost:8000
+        fetch_limit: 100
+        event_id_types: ["latest", "oldest", "recommended"]
+
+  # Priority #6 - Filter dropdowns, 2,160 req/s in prod
+  OrganizationTags:
+    host: http://localhost:8000
+    wait_time: constant(1)
+    weight: 1
+    tasks:
+      organization_tags_task_factory:
+        weight: 1
+        auth_token: ${AUTH_TOKEN}
+        organization_slug: your-org-slug
+        # project_ids: [1234, 5678]
+        stats_periods: ["90d", "24h", "12h", "1h"]
+        datasets: ["errors", "discover"]
+        queries: ["", "is:unresolved"]
+
+  # Priority #7 - Issue events list, highest latency (p95 1,480ms)
+  GroupEvents:
+    host: http://localhost:8000
+    wait_time: constant(1)
+    weight: 1
+    tasks:
+      group_events_task_factory:
+        weight: 1
+        auth_token: ${AUTH_TOKEN}
+        organization_slug: your-org-slug
+        host: http://localhost:8000
+        fetch_limit: 100
+        queries: ["", "is:unresolved"]
+        full_options: [true, false]
+        stats_periods: ["90d", "24h", "12h", "1h"]
+        per_page_values: [10, 25, 50]
+
+  # Priority #8 - Release listing, p95 614ms
+  OrganizationReleases:
+    host: http://localhost:8000
+    wait_time: constant(1)
+    weight: 1
+    tasks:
+      organization_releases_task_factory:
+        weight: 1
+        auth_token: ${AUTH_TOKEN}
+        organization_slug: your-org-slug
+        # project_ids: [1234, 5678]
+        per_page_values: [10, 25, 50]
+        sort_options: ["date", "sessions", "crash_free_users"]
+        queries: [""]
+        health_stat_options: ["sessions", ""]
+        stats_periods: ["90d", "24h", "12h"]
+
+  # Priority #9 - Project-scoped issue list, p95 1,043ms
+  ProjectGroupIndex:
+    host: http://localhost:8000
+    wait_time: constant(1)
+    weight: 1
+    tasks:
+      project_group_index_task_factory:
+        weight: 1
+        auth_token: ${AUTH_TOKEN}
+        organization_slug: your-org-slug
+        project_slugs: ["your-project-slug"]
+        stats_periods: ["90d", "24h", "12h", "1h"]
+        limits: [25, 50, 100]
+        sort_options: ["date", "freq", "new", "trends"]
+        queries: ["is:unresolved", ""]
+
+  # Priority #10 - Companion to issue list, 808 req/s in prod
+  OrganizationGroupIndexStats:
+    host: http://localhost:8000
+    wait_time: constant(1)
+    weight: 1
+    tasks:
+      organization_group_index_stats_task_factory:
+        weight: 1
+        auth_token: ${AUTH_TOKEN}
+        organization_slug: your-org-slug
+        host: http://localhost:8000
+        fetch_limit: 100
+        batch_size: 25
+        # project_ids: [1234, 5678]
+        stats_periods: ["90d", "24h", "12h", "1h"]
+        queries: ["is:unresolved", ""]

--- a/default_config/read_api.test.yml
+++ b/default_config/read_api.test.yml
@@ -105,8 +105,7 @@ users:
         organization_slug: your-org-slug
         # project_ids: [1234, 5678]
         stats_periods: ["90d", "24h", "12h", "1h"]
-        datasets: ["errors", "discover"]
-        queries: ["", "is:unresolved"]
+        datasets: ["events", "discover"]
 
   # Priority #7 - Issue events list, highest latency (p95 1,480ms)
   GroupEvents:
@@ -140,7 +139,7 @@ users:
         sort_options: ["date", "sessions", "crash_free_users"]
         queries: [""]
         health_stat_options: ["sessions", ""]
-        stats_periods: ["90d", "24h", "12h"]
+        summary_stats_periods: ["24h", "48h", "7d", "14d"]
 
   # Priority #9 - Project-scoped issue list, p95 1,043ms
   ProjectGroupIndex:
@@ -153,7 +152,7 @@ users:
         auth_token: ${AUTH_TOKEN}
         organization_slug: your-org-slug
         project_slugs: ["your-project-slug"]
-        stats_periods: ["90d", "24h", "12h", "1h"]
+        stats_periods: ["24h", "14d"]
         limits: [25, 50, 100]
         sort_options: ["date", "freq", "new", "trends"]
         queries: ["is:unresolved", ""]
@@ -173,4 +172,5 @@ users:
         batch_size: 25
         # project_ids: [1234, 5678]
         stats_periods: ["90d", "24h", "12h", "1h"]
+        group_stats_periods: ["24h", "14d", "auto"]
         queries: ["is:unresolved", ""]

--- a/default_config/read_api.test.yml
+++ b/default_config/read_api.test.yml
@@ -79,7 +79,6 @@ users:
         queries: ["", "event.type:error"]
         datasets: ["discover", "errors"]
 
-  # Priority #5 - Issue event detail, 1,490 req/s in prod
   GroupEventDetails:
     host: http://localhost:8000
     wait_time: constant(1)
@@ -93,7 +92,6 @@ users:
         fetch_limit: 100
         event_id_types: ["latest", "oldest", "recommended"]
 
-  # Priority #6 - Filter dropdowns, 2,160 req/s in prod
   OrganizationTags:
     host: http://localhost:8000
     wait_time: constant(1)
@@ -107,7 +105,6 @@ users:
         stats_periods: ["90d", "24h", "12h", "1h"]
         datasets: ["events", "discover"]
 
-  # Priority #7 - Issue events list, highest latency (p95 1,480ms)
   GroupEvents:
     host: http://localhost:8000
     wait_time: constant(1)
@@ -119,12 +116,10 @@ users:
         organization_slug: your-org-slug
         host: http://localhost:8000
         fetch_limit: 100
-        queries: ["", "is:unresolved"]
         full_options: [true, false]
         stats_periods: ["90d", "24h", "12h", "1h"]
         per_page_values: [10, 25, 50]
 
-  # Priority #8 - Release listing, p95 614ms
   OrganizationReleases:
     host: http://localhost:8000
     wait_time: constant(1)
@@ -141,7 +136,6 @@ users:
         health_stat_options: ["sessions", ""]
         summary_stats_periods: ["24h", "48h", "7d", "14d"]
 
-  # Priority #9 - Project-scoped issue list, p95 1,043ms
   ProjectGroupIndex:
     host: http://localhost:8000
     wait_time: constant(1)
@@ -151,13 +145,12 @@ users:
         weight: 1
         auth_token: ${AUTH_TOKEN}
         organization_slug: your-org-slug
-        project_slugs: ["your-project-slug"]
+        project_slugs: ["your-project-slug"] # real project slug required
         stats_periods: ["24h", "14d"]
         limits: [25, 50, 100]
-        sort_options: ["date", "freq", "new", "trends"]
+        sort_options: ["date", "new"]
         queries: ["is:unresolved", ""]
 
-  # Priority #10 - Companion to issue list, 808 req/s in prod
   OrganizationGroupIndexStats:
     host: http://localhost:8000
     wait_time: constant(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@ dependencies =[
     "influxdb-client==1.24.0"  #29.11.2021 send metrics to influxdb
 ]
 
+[dependency-groups]
+dev = [
+    "pytest",
+]
+
 [tool.uv]
 environments = ["sys_platform == 'darwin' or sys_platform == 'linux'"]
 

--- a/read_api_locustfile.py
+++ b/read_api_locustfile.py
@@ -19,6 +19,14 @@ organization_events_stats_task_factory = (
     read_api_tasks.organization_events_stats_task_factory
 )
 group_details_task_factory = read_api_tasks.group_details_task_factory
+group_event_details_task_factory = read_api_tasks.group_event_details_task_factory
+organization_tags_task_factory = read_api_tasks.organization_tags_task_factory
+group_events_task_factory = read_api_tasks.group_events_task_factory
+organization_releases_task_factory = read_api_tasks.organization_releases_task_factory
+project_group_index_task_factory = read_api_tasks.project_group_index_task_factory
+organization_group_index_stats_task_factory = (
+    read_api_tasks.organization_group_index_stats_task_factory
+)
 
 _config_path = full_path_from_module_relative_path(__file__, "config/read_api.test.yml")
 
@@ -30,3 +38,11 @@ OrganizationEventsStats = create_user_class(
     "OrganizationEventsStats", _config_path, __name__
 )
 GroupDetails = create_user_class("GroupDetails", _config_path, __name__)
+GroupEventDetails = create_user_class("GroupEventDetails", _config_path, __name__)
+OrganizationTags = create_user_class("OrganizationTags", _config_path, __name__)
+GroupEvents = create_user_class("GroupEvents", _config_path, __name__)
+OrganizationReleases = create_user_class("OrganizationReleases", _config_path, __name__)
+ProjectGroupIndex = create_user_class("ProjectGroupIndex", _config_path, __name__)
+OrganizationGroupIndexStats = create_user_class(
+    "OrganizationGroupIndexStats", _config_path, __name__
+)

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -279,6 +279,285 @@ def group_details_task_factory(task_params=None):
     return inner
 
 
+def group_event_details_task_factory(task_params=None):
+    """
+    Issue event detail endpoint:
+      GET /api/0/organizations/{org}/issues/{id}/events/{event_id}/
+
+    Pre-fetches real issue IDs at construction time. Each request picks a random
+    issue and a random event_id type (latest, oldest, recommended).
+    """
+    if task_params is None:
+        task_params = {}
+
+    auth_token = _get_auth_token(task_params)
+    org_slug = task_params.get("organization_slug", "sentry")
+    host = _resolve_env_var(task_params.get("host", "")) or os.environ.get("API_HOST")
+    fetch_limit = task_params.get("fetch_limit", 100)
+    event_id_types = task_params.get(
+        "event_id_types", ["latest", "oldest", "recommended"]
+    )
+
+    issue_ids = _fetch_issue_ids(host, auth_token, org_slug, fetch_limit)
+    if not issue_ids:
+        raise ValueError(
+            f"Failed to fetch issue IDs for org '{org_slug}'. "
+            f"Ensure host (got: {host!r}) and auth_token are correct."
+        )
+
+    logger.info("Fetched %d issue IDs for group_event_details", len(issue_ids))
+
+    headers = _read_headers(auth_token)
+    name = f"/api/0/organizations/{org_slug}/issues/{{id}}/events/{{event_id}}/"
+
+    def inner(user):
+        issue_id = random.choice(issue_ids)
+        event_id = _choice(event_id_types, "latest")
+        path = f"/api/0/organizations/{org_slug}/issues/{issue_id}/events/{event_id}/"
+        return user.client.get(path, headers=headers, name=name)
+
+    return inner
+
+
+def organization_tags_task_factory(task_params=None):
+    """
+    Organization tags endpoint: GET /api/0/organizations/{org}/tags/
+
+    Powers filter dropdowns across the UI. Randomizes statsPeriod, dataset,
+    query, and optional project filter per request.
+    """
+    if task_params is None:
+        task_params = {}
+
+    auth_token = _get_auth_token(task_params)
+    org_slug = task_params.get("organization_slug", "sentry")
+    project_ids = task_params.get("project_ids", [])
+    stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
+    datasets = task_params.get("datasets", ["errors", "discover"])
+    queries = task_params.get("queries", ["", "is:unresolved"])
+
+    base_path = f"/api/0/organizations/{org_slug}/tags/"
+    headers = _read_headers(auth_token)
+
+    def inner(user):
+        params = [("statsPeriod", _choice(stats_periods, "24h"))]
+
+        dataset = _choice(datasets, "")
+        if dataset:
+            params.append(("dataset", dataset))
+
+        query = _choice(queries, "")
+        if query:
+            params.append(("query", query))
+
+        if project_ids:
+            params.append(("project", random.choice(project_ids)))
+
+        url = _build_query_url(base_path, params)
+        return user.client.get(url, headers=headers, name=base_path)
+
+    return inner
+
+
+def group_events_task_factory(task_params=None):
+    """
+    Issue events list endpoint: GET /api/0/organizations/{org}/issues/{id}/events/
+
+    Second-highest latency endpoint (p95 1,480ms). Pre-fetches real issue IDs.
+    Randomizes query, full (triggers expensive serialization), statsPeriod, and
+    per_page per request.
+    """
+    if task_params is None:
+        task_params = {}
+
+    auth_token = _get_auth_token(task_params)
+    org_slug = task_params.get("organization_slug", "sentry")
+    host = _resolve_env_var(task_params.get("host", "")) or os.environ.get("API_HOST")
+    fetch_limit = task_params.get("fetch_limit", 100)
+    queries = task_params.get("queries", ["", "is:unresolved"])
+    full_options = task_params.get("full_options", [True, False])
+    stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
+    per_page_values = task_params.get("per_page_values", [10, 25, 50])
+
+    issue_ids = _fetch_issue_ids(host, auth_token, org_slug, fetch_limit)
+    if not issue_ids:
+        raise ValueError(
+            f"Failed to fetch issue IDs for org '{org_slug}'. "
+            f"Ensure host (got: {host!r}) and auth_token are correct."
+        )
+
+    logger.info("Fetched %d issue IDs for group_events", len(issue_ids))
+
+    headers = _read_headers(auth_token)
+    name = f"/api/0/organizations/{org_slug}/issues/{{id}}/events/"
+
+    def inner(user):
+        issue_id = random.choice(issue_ids)
+        params = [
+            ("statsPeriod", _choice(stats_periods, "24h")),
+            ("per_page", _choice(per_page_values, 10)),
+        ]
+
+        query = _choice(queries, "")
+        if query:
+            params.append(("query", query))
+
+        if _choice(full_options, False):
+            params.append(("full", "true"))
+
+        path = f"/api/0/organizations/{org_slug}/issues/{issue_id}/events/"
+        url = _build_query_url(path, params)
+        return user.client.get(url, headers=headers, name=name)
+
+    return inner
+
+
+def organization_releases_task_factory(task_params=None):
+    """
+    Release listing endpoint: GET /api/0/organizations/{org}/releases/
+
+    Randomizes per_page, sort, query, healthStat, and optional project filter.
+    """
+    if task_params is None:
+        task_params = {}
+
+    auth_token = _get_auth_token(task_params)
+    org_slug = task_params.get("organization_slug", "sentry")
+    project_ids = task_params.get("project_ids", [])
+    per_page_values = task_params.get("per_page_values", [10, 25, 50])
+    sort_options = task_params.get(
+        "sort_options", ["date", "sessions", "crash_free_users"]
+    )
+    queries = task_params.get("queries", [""])
+    health_stat_options = task_params.get("health_stat_options", ["sessions", ""])
+    stats_periods = task_params.get("stats_periods", ["24h", "12h"])
+
+    base_path = f"/api/0/organizations/{org_slug}/releases/"
+    headers = _read_headers(auth_token)
+
+    def inner(user):
+        params = [
+            ("per_page", _choice(per_page_values, 10)),
+            ("sort", _choice(sort_options, "date")),
+            ("statsPeriod", _choice(stats_periods, "24h")),
+        ]
+
+        query = _choice(queries, "")
+        if query:
+            params.append(("query", query))
+
+        health_stat = _choice(health_stat_options, "")
+        if health_stat:
+            params.append(("healthStat", health_stat))
+
+        if project_ids:
+            params.append(("project", random.choice(project_ids)))
+
+        url = _build_query_url(base_path, params)
+        return user.client.get(url, headers=headers, name=base_path)
+
+    return inner
+
+
+def project_group_index_task_factory(task_params=None):
+    """
+    Project-scoped issue list: GET /api/0/projects/{org}/{project_slug}/issues/
+
+    Same Snuba search path as organization_group_index but scoped to a single
+    project. Requires project_slugs in config.
+    """
+    if task_params is None:
+        task_params = {}
+
+    auth_token = _get_auth_token(task_params)
+    org_slug = task_params.get("organization_slug", "sentry")
+    project_slugs = task_params.get("project_slugs", [])
+    if not project_slugs:
+        raise ValueError(
+            "project_slugs is required for project_group_index. "
+            "Provide a list of project slugs in task params."
+        )
+
+    stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
+    limits = task_params.get("limits", [25, 50, 100])
+    sort_options = task_params.get("sort_options", ["date", "freq", "new", "trends"])
+    queries = task_params.get("queries", ["is:unresolved", ""])
+
+    headers = _read_headers(auth_token)
+    name = f"/api/0/projects/{org_slug}/{{project_slug}}/issues/"
+
+    def inner(user):
+        project_slug = random.choice(project_slugs)
+        params = [
+            ("statsPeriod", _choice(stats_periods, "24h")),
+            ("sort", _choice(sort_options, "date")),
+            ("limit", _choice(limits, 25)),
+        ]
+
+        query = _choice(queries, "is:unresolved")
+        if query:
+            params.append(("query", query))
+
+        path = f"/api/0/projects/{org_slug}/{project_slug}/issues/"
+        url = _build_query_url(path, params)
+        return user.client.get(url, headers=headers, name=name)
+
+    return inner
+
+
+def organization_group_index_stats_task_factory(task_params=None):
+    """
+    Issues stats companion endpoint: GET /api/0/organizations/{org}/issues-stats/
+
+    Fired alongside the issue list to fetch sparkline data. Pre-fetches real
+    issue IDs, then sends batches of group IDs per request.
+    """
+    if task_params is None:
+        task_params = {}
+
+    auth_token = _get_auth_token(task_params)
+    org_slug = task_params.get("organization_slug", "sentry")
+    host = _resolve_env_var(task_params.get("host", "")) or os.environ.get("API_HOST")
+    fetch_limit = task_params.get("fetch_limit", 100)
+    batch_size = task_params.get("batch_size", 25)
+    project_ids = task_params.get("project_ids", [])
+    stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
+    queries = task_params.get("queries", ["is:unresolved", ""])
+
+    issue_ids = _fetch_issue_ids(host, auth_token, org_slug, fetch_limit)
+    if not issue_ids:
+        raise ValueError(
+            f"Failed to fetch issue IDs for org '{org_slug}'. "
+            f"Ensure host (got: {host!r}) and auth_token are correct."
+        )
+
+    logger.info(
+        "Fetched %d issue IDs for organization_group_index_stats", len(issue_ids)
+    )
+
+    base_path = f"/api/0/organizations/{org_slug}/issues-stats/"
+    headers = _read_headers(auth_token)
+
+    def inner(user):
+        sample_size = min(batch_size, len(issue_ids))
+        batch = random.sample(issue_ids, sample_size)
+        params = [("groups", gid) for gid in batch]
+
+        params.append(("statsPeriod", _choice(stats_periods, "24h")))
+
+        query = _choice(queries, "")
+        if query:
+            params.append(("query", query))
+
+        if project_ids:
+            params.append(("project", random.choice(project_ids)))
+
+        url = _build_query_url(base_path, params)
+        return user.client.get(url, headers=headers, name=base_path)
+
+    return inner
+
+
 def _fetch_issue_ids(host, auth_token, org_slug, limit):
     if not host:
         raise ValueError(

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -369,7 +369,7 @@ def group_events_task_factory(task_params=None):
     org_slug = task_params.get("organization_slug", "sentry")
     host = _resolve_env_var(task_params.get("host", "")) or os.environ.get("API_HOST")
     fetch_limit = task_params.get("fetch_limit", 100)
-    queries = task_params.get("queries", ["", "is:unresolved"])
+    queries = task_params.get("queries", [""])
     full_options = task_params.get("full_options", [True, False])
     stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
     per_page_values = task_params.get("per_page_values", [10, 25, 50])
@@ -487,7 +487,7 @@ def project_group_index_task_factory(task_params=None):
 
     stats_periods = task_params.get("stats_periods", ["24h", "14d"])
     limits = task_params.get("limits", [25, 50, 100])
-    sort_options = task_params.get("sort_options", ["date", "freq", "new", "trends"])
+    sort_options = task_params.get("sort_options", ["date", "new"])
     queries = task_params.get("queries", ["is:unresolved", ""])
 
     headers = _read_headers(auth_token)

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -324,7 +324,7 @@ def organization_tags_task_factory(task_params=None):
     Organization tags endpoint: GET /api/0/organizations/{org}/tags/
 
     Powers filter dropdowns across the UI. Randomizes statsPeriod, dataset,
-    query, and optional project filter per request.
+    and optional project filter per request.
     """
     if task_params is None:
         task_params = {}
@@ -333,8 +333,7 @@ def organization_tags_task_factory(task_params=None):
     org_slug = task_params.get("organization_slug", "sentry")
     project_ids = task_params.get("project_ids", [])
     stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
-    datasets = task_params.get("datasets", ["errors", "discover"])
-    queries = task_params.get("queries", ["", "is:unresolved"])
+    datasets = task_params.get("datasets", ["events", "discover"])
 
     base_path = f"/api/0/organizations/{org_slug}/tags/"
     headers = _read_headers(auth_token)
@@ -345,10 +344,6 @@ def organization_tags_task_factory(task_params=None):
         dataset = _choice(datasets, "")
         if dataset:
             params.append(("dataset", dataset))
-
-        query = _choice(queries, "")
-        if query:
-            params.append(("query", query))
 
         if project_ids:
             params.append(("project", random.choice(project_ids)))
@@ -416,7 +411,8 @@ def organization_releases_task_factory(task_params=None):
     """
     Release listing endpoint: GET /api/0/organizations/{org}/releases/
 
-    Randomizes per_page, sort, query, healthStat, and optional project filter.
+    Randomizes per_page, sort, query, summaryStatsPeriod, healthStat, and
+    optional project filter. Session-based sorts require flatten=1.
     """
     if task_params is None:
         task_params = {}
@@ -430,17 +426,28 @@ def organization_releases_task_factory(task_params=None):
     )
     queries = task_params.get("queries", [""])
     health_stat_options = task_params.get("health_stat_options", ["sessions", ""])
-    stats_periods = task_params.get("stats_periods", ["24h", "12h"])
+    summary_stats_periods = task_params.get(
+        "summary_stats_periods", ["24h", "48h", "7d", "14d"]
+    )
+
+    _session_sorts = frozenset(
+        ["crash_free_sessions", "crash_free_users", "sessions", "users",
+         "sessions_24h", "users_24h"]
+    )
 
     base_path = f"/api/0/organizations/{org_slug}/releases/"
     headers = _read_headers(auth_token)
 
     def inner(user):
+        sort = _choice(sort_options, "date")
         params = [
             ("per_page", _choice(per_page_values, 10)),
-            ("sort", _choice(sort_options, "date")),
-            ("statsPeriod", _choice(stats_periods, "24h")),
+            ("sort", sort),
+            ("summaryStatsPeriod", _choice(summary_stats_periods, "24h")),
         ]
+
+        if sort in _session_sorts:
+            params.append(("flatten", "1"))
 
         query = _choice(queries, "")
         if query:
@@ -478,7 +485,7 @@ def project_group_index_task_factory(task_params=None):
             "Provide a list of project slugs in task params."
         )
 
-    stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
+    stats_periods = task_params.get("stats_periods", ["24h", "14d"])
     limits = task_params.get("limits", [25, 50, 100])
     sort_options = task_params.get("sort_options", ["date", "freq", "new", "trends"])
     queries = task_params.get("queries", ["is:unresolved", ""])
@@ -522,6 +529,9 @@ def organization_group_index_stats_task_factory(task_params=None):
     batch_size = task_params.get("batch_size", 25)
     project_ids = task_params.get("project_ids", [])
     stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
+    group_stats_periods = task_params.get(
+        "group_stats_periods", ["24h", "14d", "auto"]
+    )
     queries = task_params.get("queries", ["is:unresolved", ""])
 
     issue_ids = _fetch_issue_ids(host, auth_token, org_slug, fetch_limit)
@@ -544,6 +554,7 @@ def organization_group_index_stats_task_factory(task_params=None):
         params = [("groups", gid) for gid in batch]
 
         params.append(("statsPeriod", _choice(stats_periods, "24h")))
+        params.append(("groupStatsPeriod", _choice(group_stats_periods, "24h")))
 
         query = _choice(queries, "")
         if query:

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -431,8 +431,14 @@ def organization_releases_task_factory(task_params=None):
     )
 
     _session_sorts = frozenset(
-        ["crash_free_sessions", "crash_free_users", "sessions", "users",
-         "sessions_24h", "users_24h"]
+        [
+            "crash_free_sessions",
+            "crash_free_users",
+            "sessions",
+            "users",
+            "sessions_24h",
+            "users_24h",
+        ]
     )
 
     base_path = f"/api/0/organizations/{org_slug}/releases/"
@@ -529,9 +535,7 @@ def organization_group_index_stats_task_factory(task_params=None):
     batch_size = task_params.get("batch_size", 25)
     project_ids = task_params.get("project_ids", [])
     stats_periods = task_params.get("stats_periods", ["24h", "12h", "1h"])
-    group_stats_periods = task_params.get(
-        "group_stats_periods", ["24h", "14d", "auto"]
-    )
+    group_stats_periods = task_params.get("group_stats_periods", ["24h", "14d", "auto"])
     queries = task_params.get("queries", ["is:unresolved", ""])
 
     issue_ids = _fetch_issue_ids(host, auth_token, org_slug, fetch_limit)

--- a/tasks/read_api_tasks.py
+++ b/tasks/read_api_tasks.py
@@ -358,8 +358,7 @@ def group_events_task_factory(task_params=None):
     """
     Issue events list endpoint: GET /api/0/organizations/{org}/issues/{id}/events/
 
-    Second-highest latency endpoint (p95 1,480ms). Pre-fetches real issue IDs.
-    Randomizes query, full (triggers expensive serialization), statsPeriod, and
+    Pre-fetches real issue IDs.Randomizes query, full (triggers expensive serialization), statsPeriod, and
     per_page per request.
     """
     if task_params is None:

--- a/tests/test_read_api_tasks.py
+++ b/tests/test_read_api_tasks.py
@@ -12,9 +12,15 @@ from tasks.read_api_tasks import (
     _read_headers,
     _resolve_env_var,
     group_details_task_factory,
+    group_event_details_task_factory,
+    group_events_task_factory,
     organization_events_stats_task_factory,
     organization_events_task_factory,
+    organization_group_index_stats_task_factory,
     organization_group_index_task_factory,
+    organization_releases_task_factory,
+    organization_tags_task_factory,
+    project_group_index_task_factory,
 )
 
 
@@ -339,3 +345,411 @@ class TestGroupDetails:
         name = user.client.get.call_args[1]["name"]
         assert "{id}" in name
         assert "99" not in name
+
+
+class TestGroupEventDetails:
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_factory_returns_callable(self, mock_fetch):
+        mock_fetch.return_value = ["111", "222"]
+        task = group_event_details_task_factory(
+            {"auth_token": "tok", "host": "https://sentry.io"}
+        )
+        assert callable(task)
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_url_uses_event_id_type(self, mock_fetch):
+        mock_fetch.return_value = ["42"]
+        task = group_event_details_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "host": "https://sentry.io",
+                "event_id_types": ["recommended"],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert url == "/api/0/organizations/myorg/issues/42/events/recommended/"
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_name_param_uses_template(self, mock_fetch):
+        mock_fetch.return_value = ["99"]
+        task = group_event_details_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "sentry",
+                "host": "https://sentry.io",
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        name = user.client.get.call_args[1]["name"]
+        assert "{id}" in name
+        assert "{event_id}" in name
+        assert "99" not in name
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_no_issue_ids_raises(self, mock_fetch):
+        mock_fetch.return_value = []
+        with pytest.raises(ValueError, match="Failed to fetch issue IDs"):
+            group_event_details_task_factory(
+                {"auth_token": "tok", "host": "https://sentry.io"}
+            )
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_bearer_auth_header(self, mock_fetch):
+        mock_fetch.return_value = ["1"]
+        task = group_event_details_task_factory(
+            {"auth_token": "secret", "host": "https://sentry.io"}
+        )
+        user = _make_mock_user()
+        task(user)
+
+        headers = user.client.get.call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer secret"
+
+
+class TestOrganizationTags:
+    def test_factory_returns_callable(self):
+        task = organization_tags_task_factory({"auth_token": "tok"})
+        assert callable(task)
+
+    def test_request_url_structure(self):
+        task = organization_tags_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "stats_periods": ["1h"],
+                "datasets": [""],
+                "queries": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert url.startswith("/api/0/organizations/myorg/tags/")
+        assert "statsPeriod=1h" in url
+        assert (
+            user.client.get.call_args[1]["name"] == "/api/0/organizations/myorg/tags/"
+        )
+
+    def test_optional_dataset(self):
+        task = organization_tags_task_factory(
+            {
+                "auth_token": "tok",
+                "datasets": ["errors"],
+                "stats_periods": ["1h"],
+                "queries": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "dataset=errors" in url
+
+    def test_optional_project_filter(self):
+        task = organization_tags_task_factory(
+            {
+                "auth_token": "tok",
+                "project_ids": [42],
+                "stats_periods": ["1h"],
+                "datasets": [""],
+                "queries": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "project=42" in url
+
+
+class TestGroupEvents:
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_factory_returns_callable(self, mock_fetch):
+        mock_fetch.return_value = ["111"]
+        task = group_events_task_factory(
+            {"auth_token": "tok", "host": "https://sentry.io"}
+        )
+        assert callable(task)
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_url_contains_issue_id(self, mock_fetch):
+        mock_fetch.return_value = ["42"]
+        task = group_events_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "host": "https://sentry.io",
+                "stats_periods": ["24h"],
+                "per_page_values": [10],
+                "queries": [""],
+                "full_options": [False],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "/issues/42/events/" in url
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_full_param(self, mock_fetch):
+        mock_fetch.return_value = ["1"]
+        task = group_events_task_factory(
+            {
+                "auth_token": "tok",
+                "host": "https://sentry.io",
+                "stats_periods": ["24h"],
+                "per_page_values": [10],
+                "queries": [""],
+                "full_options": [True],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "full=true" in url
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_name_param_uses_template(self, mock_fetch):
+        mock_fetch.return_value = ["99"]
+        task = group_events_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "sentry",
+                "host": "https://sentry.io",
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        name = user.client.get.call_args[1]["name"]
+        assert "{id}" in name
+        assert "99" not in name
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_no_issue_ids_raises(self, mock_fetch):
+        mock_fetch.return_value = []
+        with pytest.raises(ValueError, match="Failed to fetch issue IDs"):
+            group_events_task_factory(
+                {"auth_token": "tok", "host": "https://sentry.io"}
+            )
+
+
+class TestOrganizationReleases:
+    def test_factory_returns_callable(self):
+        task = organization_releases_task_factory({"auth_token": "tok"})
+        assert callable(task)
+
+    def test_request_url_structure(self):
+        task = organization_releases_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "per_page_values": [25],
+                "sort_options": ["date"],
+                "stats_periods": ["24h"],
+                "queries": [""],
+                "health_stat_options": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert url.startswith("/api/0/organizations/myorg/releases/")
+        assert "per_page=25" in url
+        assert "sort=date" in url
+        assert "statsPeriod=24h" in url
+        assert (
+            user.client.get.call_args[1]["name"]
+            == "/api/0/organizations/myorg/releases/"
+        )
+
+    def test_health_stat_param(self):
+        task = organization_releases_task_factory(
+            {
+                "auth_token": "tok",
+                "per_page_values": [10],
+                "sort_options": ["date"],
+                "stats_periods": ["24h"],
+                "queries": [""],
+                "health_stat_options": ["sessions"],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "healthStat=sessions" in url
+
+    def test_optional_project_filter(self):
+        task = organization_releases_task_factory(
+            {
+                "auth_token": "tok",
+                "project_ids": [42],
+                "per_page_values": [10],
+                "sort_options": ["date"],
+                "stats_periods": ["24h"],
+                "queries": [""],
+                "health_stat_options": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "project=42" in url
+
+
+class TestProjectGroupIndex:
+    def test_factory_returns_callable(self):
+        task = project_group_index_task_factory(
+            {"auth_token": "tok", "project_slugs": ["my-project"]}
+        )
+        assert callable(task)
+
+    def test_request_url_structure(self):
+        task = project_group_index_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "project_slugs": ["web-app"],
+                "stats_periods": ["1h"],
+                "limits": [25],
+                "sort_options": ["date"],
+                "queries": ["is:unresolved"],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert url.startswith("/api/0/projects/myorg/web-app/issues/")
+        assert "statsPeriod=1h" in url
+        assert "sort=date" in url
+        assert "limit=25" in url
+
+    def test_name_param_uses_template(self):
+        task = project_group_index_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "project_slugs": ["web-app"],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        name = user.client.get.call_args[1]["name"]
+        assert "{project_slug}" in name
+        assert "web-app" not in name
+
+    def test_missing_project_slugs_raises(self):
+        with pytest.raises(ValueError, match="project_slugs is required"):
+            project_group_index_task_factory({"auth_token": "tok"})
+
+    def test_empty_project_slugs_raises(self):
+        with pytest.raises(ValueError, match="project_slugs is required"):
+            project_group_index_task_factory({"auth_token": "tok", "project_slugs": []})
+
+
+class TestOrganizationGroupIndexStats:
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_factory_returns_callable(self, mock_fetch):
+        mock_fetch.return_value = ["111", "222"]
+        task = organization_group_index_stats_task_factory(
+            {"auth_token": "tok", "host": "https://sentry.io"}
+        )
+        assert callable(task)
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_request_url_structure(self, mock_fetch):
+        mock_fetch.return_value = ["1", "2", "3"]
+        task = organization_group_index_stats_task_factory(
+            {
+                "auth_token": "tok",
+                "organization_slug": "myorg",
+                "host": "https://sentry.io",
+                "batch_size": 2,
+                "stats_periods": ["24h"],
+                "queries": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert url.startswith("/api/0/organizations/myorg/issues-stats/")
+        assert "groups=" in url
+        assert "statsPeriod=24h" in url
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_multi_value_groups(self, mock_fetch):
+        mock_fetch.return_value = [str(i) for i in range(30)]
+        task = organization_group_index_stats_task_factory(
+            {
+                "auth_token": "tok",
+                "host": "https://sentry.io",
+                "batch_size": 5,
+                "stats_periods": ["24h"],
+                "queries": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert url.count("groups=") == 5
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_batch_size_capped_at_available(self, mock_fetch):
+        mock_fetch.return_value = ["1", "2", "3"]
+        task = organization_group_index_stats_task_factory(
+            {
+                "auth_token": "tok",
+                "host": "https://sentry.io",
+                "batch_size": 25,
+                "stats_periods": ["24h"],
+                "queries": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert url.count("groups=") == 3
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_no_issue_ids_raises(self, mock_fetch):
+        mock_fetch.return_value = []
+        with pytest.raises(ValueError, match="Failed to fetch issue IDs"):
+            organization_group_index_stats_task_factory(
+                {"auth_token": "tok", "host": "https://sentry.io"}
+            )
+
+    @patch("tasks.read_api_tasks._fetch_issue_ids")
+    def test_optional_project_filter(self, mock_fetch):
+        mock_fetch.return_value = ["1"]
+        task = organization_group_index_stats_task_factory(
+            {
+                "auth_token": "tok",
+                "host": "https://sentry.io",
+                "project_ids": [42],
+                "batch_size": 1,
+                "stats_periods": ["24h"],
+                "queries": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "project=42" in url

--- a/tests/test_read_api_tasks.py
+++ b/tests/test_read_api_tasks.py
@@ -424,7 +424,6 @@ class TestOrganizationTags:
                 "organization_slug": "myorg",
                 "stats_periods": ["1h"],
                 "datasets": [""],
-                "queries": [""],
             }
         )
         user = _make_mock_user()
@@ -441,16 +440,15 @@ class TestOrganizationTags:
         task = organization_tags_task_factory(
             {
                 "auth_token": "tok",
-                "datasets": ["errors"],
+                "datasets": ["events"],
                 "stats_periods": ["1h"],
-                "queries": [""],
             }
         )
         user = _make_mock_user()
         task(user)
 
         url = user.client.get.call_args[0][0]
-        assert "dataset=errors" in url
+        assert "dataset=events" in url
 
     def test_optional_project_filter(self):
         task = organization_tags_task_factory(
@@ -459,7 +457,6 @@ class TestOrganizationTags:
                 "project_ids": [42],
                 "stats_periods": ["1h"],
                 "datasets": [""],
-                "queries": [""],
             }
         )
         user = _make_mock_user()
@@ -555,7 +552,7 @@ class TestOrganizationReleases:
                 "organization_slug": "myorg",
                 "per_page_values": [25],
                 "sort_options": ["date"],
-                "stats_periods": ["24h"],
+                "summary_stats_periods": ["24h"],
                 "queries": [""],
                 "health_stat_options": [""],
             }
@@ -567,11 +564,47 @@ class TestOrganizationReleases:
         assert url.startswith("/api/0/organizations/myorg/releases/")
         assert "per_page=25" in url
         assert "sort=date" in url
-        assert "statsPeriod=24h" in url
+        assert "summaryStatsPeriod=24h" in url
         assert (
             user.client.get.call_args[1]["name"]
             == "/api/0/organizations/myorg/releases/"
         )
+
+    def test_flatten_added_for_session_sorts(self):
+        task = organization_releases_task_factory(
+            {
+                "auth_token": "tok",
+                "per_page_values": [10],
+                "sort_options": ["sessions"],
+                "summary_stats_periods": ["24h"],
+                "queries": [""],
+                "health_stat_options": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "sort=sessions" in url
+        assert "flatten=1" in url
+
+    def test_no_flatten_for_date_sort(self):
+        task = organization_releases_task_factory(
+            {
+                "auth_token": "tok",
+                "per_page_values": [10],
+                "sort_options": ["date"],
+                "summary_stats_periods": ["24h"],
+                "queries": [""],
+                "health_stat_options": [""],
+            }
+        )
+        user = _make_mock_user()
+        task(user)
+
+        url = user.client.get.call_args[0][0]
+        assert "sort=date" in url
+        assert "flatten" not in url
 
     def test_health_stat_param(self):
         task = organization_releases_task_factory(
@@ -579,7 +612,7 @@ class TestOrganizationReleases:
                 "auth_token": "tok",
                 "per_page_values": [10],
                 "sort_options": ["date"],
-                "stats_periods": ["24h"],
+                "summary_stats_periods": ["24h"],
                 "queries": [""],
                 "health_stat_options": ["sessions"],
             }
@@ -597,7 +630,7 @@ class TestOrganizationReleases:
                 "project_ids": [42],
                 "per_page_values": [10],
                 "sort_options": ["date"],
-                "stats_periods": ["24h"],
+                "summary_stats_periods": ["24h"],
                 "queries": [""],
                 "health_stat_options": [""],
             }
@@ -622,7 +655,7 @@ class TestProjectGroupIndex:
                 "auth_token": "tok",
                 "organization_slug": "myorg",
                 "project_slugs": ["web-app"],
-                "stats_periods": ["1h"],
+                "stats_periods": ["24h"],
                 "limits": [25],
                 "sort_options": ["date"],
                 "queries": ["is:unresolved"],
@@ -633,7 +666,7 @@ class TestProjectGroupIndex:
 
         url = user.client.get.call_args[0][0]
         assert url.startswith("/api/0/projects/myorg/web-app/issues/")
-        assert "statsPeriod=1h" in url
+        assert "statsPeriod=24h" in url
         assert "sort=date" in url
         assert "limit=25" in url
 
@@ -680,6 +713,7 @@ class TestOrganizationGroupIndexStats:
                 "host": "https://sentry.io",
                 "batch_size": 2,
                 "stats_periods": ["24h"],
+                "group_stats_periods": ["14d"],
                 "queries": [""],
             }
         )
@@ -690,6 +724,7 @@ class TestOrganizationGroupIndexStats:
         assert url.startswith("/api/0/organizations/myorg/issues-stats/")
         assert "groups=" in url
         assert "statsPeriod=24h" in url
+        assert "groupStatsPeriod=14d" in url
 
     @patch("tasks.read_api_tasks._fetch_issue_ids")
     def test_multi_value_groups(self, mock_fetch):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "sys_platform == 'darwin' or sys_platform == 'linux'",
@@ -323,6 +323,11 @@ dependencies = [
     { name = "werkzeug", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "black", specifier = "==22.3.0" },
@@ -335,6 +340,18 @@ requires-dist = [
     { name = "sentry-relay", specifier = "==0.9.0" },
     { name = "sentry-sdk", specifier = "==1.5.8" },
     { name = "werkzeug", specifier = "==2.2.2" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -478,6 +495,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -493,6 +519,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -524,6 +559,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "iniconfig", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pluggy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pygments", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -592,7 +651,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
     { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
     { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b6/94414759a69a26c3dd674570a81813c46a078767d931a6c70ad29fc585cb/pyzmq-27.1.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:fbb4f2400bfda24f12f009cba62ad5734148569ff4949b1b6ec3b519444342e6", size = 1156301, upload-time = "2025-09-08T23:08:22.47Z" },
     { url = "https://files.pythonhosted.org/packages/a5/ad/15906493fd40c316377fd8a8f6b1f93104f97a752667763c9b9c1b71d42d/pyzmq-27.1.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:e343d067f7b151cfe4eb3bb796a7752c9d369eed007b91231e817071d2c2fec7", size = 1341197, upload-time = "2025-09-08T23:08:24.286Z" },
     { url = "https://files.pythonhosted.org/packages/14/1d/d343f3ce13db53a54cb8946594e567410b2125394dafcc0268d8dda027e0/pyzmq-27.1.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:08363b2011dec81c354d694bdecaef4770e0ae96b9afea70b3f47b973655cc05", size = 897275, upload-time = "2025-09-08T23:08:26.063Z" },
     { url = "https://files.pythonhosted.org/packages/69/2d/d83dd6d7ca929a2fc67d2c3005415cdf322af7751d773524809f9e585129/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54530c8c8b5b8ddb3318f481297441af102517602b569146185fa10b63f4fa9", size = 660469, upload-time = "2025-09-08T23:08:27.623Z" },


### PR DESCRIPTION
followup to https://github.com/getsentry/ingest-load-tester/pull/53 -- these are the 6 remaining endpoints we'll load test, according to the investigation [here](https://app.datadoghq.com/dashboard/66w-593-ysx). These follow the same pattern as the original 4 added in the linked PR, and there will be followup work to allow `ingest-load-test` to do tests across multiple orgs (not handled in this PR)

load test results from a 1m test against my local dev server (includes traffic to all 10 implemented endpoints):
<img width="1206" height="684" alt="Screenshot 2026-05-07 at 1 50 50 PM" src="https://github.com/user-attachments/assets/aaec1270-7446-45be-aa40-729291200ec3" />
